### PR TITLE
fix font warnings

### DIFF
--- a/website/build_website.roc
+++ b/website/build_website.roc
@@ -141,6 +141,7 @@ main! = |_args|
 
 run_cmd! : Str, List Str => Result {} [BadCmdOutput(Str)]_
 run_cmd! = |cmd_str, args|
+    Stdout.line!("Running command: ${cmd_str} ${Str.join_with(args, " ")}")?
     _ = run_cmd_w_output!(cmd_str, args)?
 
     Ok({})

--- a/website/flake.lock
+++ b/website/flake.lock
@@ -1,0 +1,156 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722403750,
+        "narHash": "sha256-tRmn6UiFAPX0m9G1AVcEPjWEOc9BtGsxGcs7Bz3MpsM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "184957277e885c06a505db112b35dfbec7c60494",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "184957277e885c06a505db112b35dfbec7c60494",
+        "type": "github"
+      }
+    },
+    "roc": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1754475502,
+        "narHash": "sha256-TrRSc8f+UNQeLVURqfN9j8QaJA1fXQJ0uqNmO6AMOyE=",
+        "owner": "roc-lang",
+        "repo": "roc",
+        "rev": "4da8ce8ded4859314fac1cc350c4b762930969a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "roc-lang",
+        "repo": "roc",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "roc",
+          "nixpkgs"
+        ],
+        "roc": "roc"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "roc",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1736303309,
+        "narHash": "sha256-IKrk7RL+Q/2NC6+Ql6dwwCNZI6T6JH2grTdJaVWHF0A=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a0b81d4fa349d9af1765b0f0b4a899c13776f706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/website/flake.nix
+++ b/website/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Website devShell flake";
+
+  inputs = {
+    roc.url = "github:roc-lang/roc";
+
+    nixpkgs.follows = "roc/nixpkgs";
+
+    # to easily make configs for multiple architectures
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, roc, flake-utils }:
+    let supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    in flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        rocPkgs = roc.packages.${system};
+
+        aliases = ''
+          alias buildcmd='roc ./build_website.roc'
+          alias runcmd='npx http-server ./build -c-1 -p 8080'
+        '';
+
+        linuxInputs = with pkgs;
+          lib.optionals stdenv.isLinux [
+          ];
+
+        darwinInputs = with pkgs;
+          lib.optionals stdenv.isDarwin
+          (with pkgs.darwin.apple_sdk.frameworks; [
+            #Security
+          ]);
+
+        sharedInputs = (with pkgs; [
+          nodejs_22
+          rocPkgs.cli
+        ]);
+      in {
+
+        devShell = pkgs.mkShell {
+          buildInputs = sharedInputs ++ darwinInputs ++ linuxInputs;
+
+          shellHook = ''
+            ${aliases}
+            
+            echo "Some convenient command aliases:"
+            echo "${aliases}" | grep -E "alias .*" -o | sed 's/alias /  /' | sed 's/=/ = /'
+            echo ""
+          '';
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}

--- a/website/static_site_gen.roc
+++ b/website/static_site_gen.roc
@@ -4,8 +4,8 @@ app [main!] {
 
 import pf.SSG
 import pf.Types
-import pf.Html exposing [header, nav, div, link, attribute, text, a, span, html, head, body, meta, script, footer]
-import pf.Html.Attributes exposing [id, aria_label, aria_hidden, title, href, class, rel, type, content, lang, charset, name, color]
+import pf.Html exposing [header, nav, div, link, text, a, span, html, head, body, meta, script, footer]
+import pf.Html.Attributes exposing [id, aria_label, aria_hidden, title, href, class, rel, content, lang, charset, name, color]
 import "content/tutorial.md" as tutorial_markdown : Str
 
 import InteractiveRocExample
@@ -84,19 +84,6 @@ transform : Str, Str -> Str
 transform = |page_path_str, html_content|
     Html.render(view(page_path_str, html_content))
 
-preload_woff2 : Str -> Html.Node
-preload_woff2 = |url|
-
-    link([
-        rel("preload"),
-        attribute("as")("font"),
-        type("font/woff2"),
-        href(url),
-        # Necessary for preloading fonts, even if the request won't be cross-origin
-        # https://stackoverflow.com/a/70878420
-        attribute("crossorigin")("anonymous"),
-    ])
-
 view : Str, Str -> Html.Node
 view = |page_path_str, html_content|
     main_body =
@@ -132,11 +119,6 @@ view = |page_path_str, html_content|
             meta([name("description"), content(page_info.description)]),
             meta([name("viewport"), content("width=device-width")]),
             link([rel("icon"), href("/favicon.svg")]),
-            # Preload the latin-regular (but not latin-ext) unicode ranges of our fonts.
-            # The homepage doesn't actually use latin-ext
-            preload_woff2("/fonts/lato-v23-latin/lato-v23-latin-regular.woff2"),
-            preload_woff2("/fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff2"),
-            preload_woff2("/fonts/permanent-marker-v16-latin/permanent-marker-v16-latin-regular.woff2"),
             link([rel("prefetch"), href("/repl/roc_repl_wasm.js")]),
             link([rel("stylesheet"), href("/site.css")]),
             # Safari ignores rel="icon" and only respects rel="mask-icon". It will render the SVG with


### PR DESCRIPTION
Closes #8

I got rid of the preloads, I still don't completely understand the "was not used" warning.

This was the last warning found in https://github.com/roc-lang/www.roc-lang.org/blob/main/.github/workflows/browser-error-warning-check.yml so I really want it gone.

I also added the nix flake in this PR.