### PR TITLE
Add missing commas to User type tutorial

### DIFF
--- a/website/content/tutorial.md
+++ b/website/content/tutorial.md
@@ -2082,8 +2082,8 @@ Since open records have a type variable (like `*` in `{ email : Str }*` or `a` i
 
 ```roc
 User a : {
-    email : Str
-    first_name : Str
+    email : Str,
+    first_name : Str,
     last_name : Str
 }a
 ```


### PR DESCRIPTION
Hey!

I was following the [roc tutorial](https://www.roc-lang.org/tutorial#type-variables-in-record-annotations), and it seems like this wouldn't compile unless I added the commas, so I'm making this change. I'm using `nix run github:roc-lang/roc` from today, if that helps isolate the roc version somehow.