### PR TITLE
Add interactive roc widget with example on front page

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,10 @@ jobs:
           cd website
           roc check build_website.roc
 
+      - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
+        with:
+          version: nightly-new-compiler
+
       - name: Test interactive Roc widgets
         run: ci_scripts/test_interactive_roc.sh
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,9 @@ jobs:
           cd website
           roc check build_website.roc
 
+      - name: Test interactive Roc widgets
+        run: ci_scripts/test_interactive_roc.sh
+
   test-install-script-unix:
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ website/.cache/
 
 # the roc wasm compiler and echo platform gets downloaded during build
 website/public/echo.wasm
+website/public/echo.wasm.zst
 
 __pycache__/
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ website/build
 website/content/examples
 website/.cache/
 
+# the roc wasm compiler and echo platform gets downloaded during build
+website/public/echo.wasm
+
 __pycache__/
 
 .DS_Store

--- a/ci_scripts/test_interactive_roc.sh
+++ b/ci_scripts/test_interactive_roc.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 # actually compiles and runs with the current Roc compiler -- the same nightly
 # used to build the docs.
 #
-# Each widget stores its source as the div's text content. An HTML comment
-# (`<!-- -->`) separates the top-level definitions from `main!`; the browser
-# excludes comments from `textContent` before handing the source to the
-# compiler, so we strip those comment lines here to reconstruct the exact
-# program the visitor runs.
+# Each widget stores its source inside a `<pre class="roc-source">` element,
+# alongside a static `<button class="roc-run">`. In the browser, compiler.js
+# removes that button and then reads the div's `textContent` -- so the `<pre>`
+# tags and the `<!-- -->` comment that separates the top-level definitions from
+# `main!` never reach the compiler. We reconstruct the exact program the visitor
+# runs by stripping the `<pre>`/`</pre>` tags, dropping the comment lines, and
+# skipping the Run button line.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONTENT_DIR="$ROOT_DIR/website/content"
@@ -33,6 +35,9 @@ while IFS= read -r md_file; do
     in_block && /<\/div>/         { in_block = 0; next }
     in_block {
       if ($0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/) next
+      if ($0 ~ /<button class="roc-run"/) next
+      gsub(/<pre class="roc-source">/, "")
+      gsub(/<\/pre>/, "")
       print > (out_dir "/" base "_" n ".roc")
     }
   ' "$md_file"

--- a/ci_scripts/test_interactive_roc.sh
+++ b/ci_scripts/test_interactive_roc.sh
@@ -10,8 +10,9 @@ set -euo pipefail
 # removes that button and then reads the div's `textContent` -- so the `<pre>`
 # tags and the `<!-- -->` comment that separates the top-level definitions from
 # `main!` never reach the compiler. We reconstruct the exact program the visitor
-# runs by stripping the `<pre>`/`</pre>` tags, dropping the comment lines, and
-# skipping the Run button line.
+# runs by stripping the `<pre>`/`</pre>` tags, replacing the comment lines with
+# blank lines (the comment node contributes nothing to `textContent`, but the
+# surrounding newlines stay), and skipping the Run button line.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONTENT_DIR="$ROOT_DIR/website/content"
@@ -29,12 +30,12 @@ while IFS= read -r md_file; do
   base="$(basename "$md_file" .md)"
 
   # Split each `<div class="roc-interactive ...">` ... `</div>` block into its
-  # own `.roc` file, dropping the `<!-- -->` comment separators.
+  # own `.roc` file, turning the `<!-- -->` comment separators into blank lines.
   awk -v out_dir="$work_dir" -v base="$base" '
     /<div class="roc-interactive/ { in_block = 1; n++; next }
     in_block && /<\/div>/         { in_block = 0; next }
     in_block {
-      if ($0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/) next
+      if ($0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/) { print "" > (out_dir "/" base "_" n ".roc"); next }
       if ($0 ~ /<button class="roc-run"/) next
       gsub(/<pre class="roc-source">/, "")
       gsub(/<\/pre>/, "")

--- a/ci_scripts/test_interactive_roc.sh
+++ b/ci_scripts/test_interactive_roc.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify the Roc code shown in the `.roc-interactive` widgets on the website
+# actually compiles and runs with the current Roc compiler -- the same nightly
+# used to build the docs.
+#
+# Each widget stores its source as the div's text content. An HTML comment
+# (`<!-- -->`) separates the top-level definitions from `main!`; the browser
+# excludes comments from `textContent` before handing the source to the
+# compiler, so we strip those comment lines here to reconstruct the exact
+# program the visitor runs.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTENT_DIR="$ROOT_DIR/website/content"
+
+# Allow overriding the compiler (defaults to `roc` on PATH, as used in CI).
+ROC="${ROC:-roc}"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+extracted=0
+failures=0
+
+while IFS= read -r md_file; do
+  base="$(basename "$md_file" .md)"
+
+  # Split each `<div class="roc-interactive ...">` ... `</div>` block into its
+  # own `.roc` file, dropping the `<!-- -->` comment separators.
+  awk -v out_dir="$work_dir" -v base="$base" '
+    /<div class="roc-interactive/ { in_block = 1; n++; next }
+    in_block && /<\/div>/         { in_block = 0; next }
+    in_block {
+      if ($0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/) next
+      print > (out_dir "/" base "_" n ".roc")
+    }
+  ' "$md_file"
+done < <(grep -rl 'class="roc-interactive' "$CONTENT_DIR")
+
+# Golden output each widget must produce when run. Keyed by the generated
+# `<md-basename>_<n>.roc` name. Asserting the exact output means the test
+# catches silent behaviour changes, not just compile/run failures. Update the
+# expected value here when you intentionally change a widget's example.
+expected_output() {
+  case "$1" in
+    index_1.roc)
+      printf -- '- Write blog post \n\n- Call mom \n\n'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+shopt -s nullglob
+for roc_file in "$work_dir"/*.roc; do
+  extracted=$((extracted + 1))
+  name="$(basename "$roc_file")"
+  echo "==> Testing interactive widget: $name"
+  echo "--- source ---"
+  cat "$roc_file"
+  echo "--- roc check ---"
+  if ! "$ROC" check "$roc_file"; then
+    echo "::error::roc check failed for an interactive widget ($name)"
+    failures=$((failures + 1))
+    continue
+  fi
+  echo "--- roc run ---"
+  actual_file="$work_dir/$name.out"
+  if ! "$ROC" "$roc_file" > "$actual_file" 2>&1; then
+    cat "$actual_file"
+    echo "::error::running an interactive widget failed ($name)"
+    failures=$((failures + 1))
+    continue
+  fi
+  cat "$actual_file"
+
+  if expected_output "$name" > "$work_dir/$name.expected"; then
+    if ! diff -u "$work_dir/$name.expected" "$actual_file"; then
+      echo "::error::output of interactive widget ($name) did not match the expected output"
+      failures=$((failures + 1))
+    fi
+  else
+    echo "::warning::no expected output registered for $name; only ran it (add one in ci_scripts/test_interactive_roc.sh)"
+  fi
+done
+
+if [ "$extracted" -eq 0 ]; then
+  echo "::error::No .roc-interactive widgets found under $CONTENT_DIR"
+  exit 1
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures interactive widget(s) failed."
+  exit 1
+fi
+
+echo "All $extracted interactive widget(s) passed."

--- a/website/build_website.roc
+++ b/website/build_website.roc
@@ -52,7 +52,7 @@ full_clean_build! = |{}|
     _ = Dir.delete_all!("roc")
     _ = Dir.delete_all!(new_compiler_dir)
 
-    # Download latest echo.wasm from nightlies for the wasm compiler
+    # Download latest echo.wasm from nightlies for the interactive compiler
     _ = File.delete!("public/echo.wasm")
     ensure_echo_wasm_present!({})?
 
@@ -231,12 +231,14 @@ ensure_repl_present! = |{}|
 ensure_echo_wasm_present! : {} => Result {} _
 ensure_echo_wasm_present! = |{}|
     wasm_path = "public/echo.wasm"
+    wasm_zst_path = "public/echo.wasm.zst"
     already = File.is_file!(wasm_path) |> Result.with_default(Bool.false)
     if already then
         Ok({})
     else
         # GitHub's /releases/latest/download/ URL redirects to the latest asset
-        Cmd.exec!("curl", ["-fsSL", "-o", wasm_path, "https://github.com/roc-lang/nightlies/releases/latest/download/echo.wasm"])?
+        Cmd.exec!("curl", ["-fsSL", "-o", wasm_zst_path, "https://github.com/roc-lang/nightlies/releases/latest/download/echo.wasm.zst"])?
+        Cmd.exec!("zstd", ["-d", "--force", wasm_zst_path, "-o", wasm_path])?
         Ok({})
 
 ensure_builtins_present! : {} => Result {} _

--- a/website/build_website.roc
+++ b/website/build_website.roc
@@ -239,6 +239,9 @@ ensure_echo_wasm_present! = |{}|
         # GitHub's /releases/latest/download/ URL redirects to the latest asset
         Cmd.exec!("curl", ["-fsSL", "-o", wasm_zst_path, "https://github.com/roc-lang/nightlies/releases/latest/download/echo.wasm.zst"])?
         Cmd.exec!("zstd", ["-d", "--force", wasm_zst_path, "-o", wasm_path])?
+        # Drop the compressed artifact so it isn't shipped; the browser fetches
+        # echo.wasm and Cloudflare compresses it on the wire via Content-Encoding.
+        File.delete!(wasm_zst_path)?
         Ok({})
 
 ensure_builtins_present! : {} => Result {} _

--- a/website/build_website.roc
+++ b/website/build_website.roc
@@ -52,6 +52,10 @@ full_clean_build! = |{}|
     _ = Dir.delete_all!("roc")
     _ = Dir.delete_all!(new_compiler_dir)
 
+    # Download latest echo.wasm from nightlies for the wasm compiler
+    _ = File.delete!("public/echo.wasm")
+    ensure_echo_wasm_present!({})?
+
     Cmd.exec!("cp", ["-r", "public", "build"])?
 
     # Download latest examples
@@ -136,6 +140,7 @@ build_with_cache! = |{}|
     ensure_examples_present!({})?
     ensure_fonts_present!({})?
     ensure_repl_present!({})?
+    ensure_echo_wasm_present!({})?
     ensure_builtins_present!({})?
 
     # 3) Only rebuild site output if content/public changed since last time
@@ -221,6 +226,17 @@ ensure_repl_present! = |{}|
         Dir.create!("build/repl") ? CreateReplDirFailed
         Cmd.exec!("tar", ["-xzf", repl_tarfile, "-C", "build/repl"])?
         _ = File.delete!(repl_tarfile)
+        Ok({})
+
+ensure_echo_wasm_present! : {} => Result {} _
+ensure_echo_wasm_present! = |{}|
+    wasm_path = "public/echo.wasm"
+    already = File.is_file!(wasm_path) |> Result.with_default(Bool.false)
+    if already then
+        Ok({})
+    else
+        # GitHub's /releases/latest/download/ URL redirects to the latest asset
+        Cmd.exec!("curl", ["-fsSL", "-o", wasm_path, "https://github.com/roc-lang/nightlies/releases/latest/download/echo.wasm"])?
         Ok({})
 
 ensure_builtins_present! : {} => Result {} _

--- a/website/content/index.md
+++ b/website/content/index.md
@@ -42,20 +42,19 @@ In its current state, the new compiler is only suited for things like programmin
 In any case, the [all syntax example](https://github.com/roc-lang/roc/blob/main/test/echo/all_syntax_test.roc) offers a great overview of the language. You can try the real compiler running in your browser below:
 
 <div class="roc-interactive front-page">
-remaining = |tasks|
+print_remaining! = |tasks|
     tasks
         .keep_if(|task| !task.done)
-        .map(|task| "☐ ${task.title}")
-        ->Str.join_with("\n")
-<!-- -->
+        .for_each!(|task| echo!("☐ ${task.name} \n"))
+<!--  -->
 main! = |_| {
     tasks = [
-        { title: "Learn Roc",       done: True },
-        { title: "Buy groceries",   done: True },
-        { title: "Write blog post", done: False },
-        { title: "Call mom",        done: False },
+        { name: "Learn Roc",       done: True },
+        { name: "Buy groceries",   done: True },
+        { name: "Write blog post", done: False },
+        { name: "Call mom",        done: False },
     ]
-    echo!(remaining(tasks))
+    print_remaining!(tasks)
     Ok({})
 }
 </div>

--- a/website/content/index.md
+++ b/website/content/index.md
@@ -39,24 +39,26 @@
 ## [Examples](#examples) {#examples}
 
 In its current state, the new compiler is only suited for things like programming puzzles.
-In any case, the [all syntax example](https://github.com/roc-lang/roc/blob/main/test/echo/all_syntax_test.roc) offers a great overview of the language. You can try the real compiler running in your browser below:
+In any case, the [all syntax example](https://github.com/roc-lang/roc/blob/main/test/echo/all_syntax_test.roc) offers a great overview of the language.
 
+You can run the full compiler in the browser without a backend server!
 <div class="roc-interactive front-page">
-print_remaining! = |tasks|
-    tasks
-        .keep_if(|task| !task.done)
-        .for_each!(|task| echo!("☐ ${task.name} \n"))
+<pre class="roc-source">print_remaining! = |todos|
+    todos
+        .keep_if(|todo| !todo.done)
+        .for_each!(|todo| echo!("- ${todo.name} \n"))
 <!--  -->
-main! = |_| {
-    tasks = [
+main! = |_args| {
+    todos = [
         { name: "Learn Roc",       done: True },
         { name: "Buy groceries",   done: True },
         { name: "Write blog post", done: False },
         { name: "Call mom",        done: False },
     ]
-    print_remaining!(tasks)
+    print_remaining!(todos)
     Ok({})
-}
+}</pre>
+<button class="roc-run">Enable JS to Run</button>
 </div>
 
 To get started with the language, try the [tutorial](https://github.com/roc-lang/roc/blob/main/docs/mini-tutorial-new-compiler.md)!

--- a/website/content/index.md
+++ b/website/content/index.md
@@ -39,7 +39,26 @@
 ## [Examples](#examples) {#examples}
 
 In its current state, the new compiler is only suited for things like programming puzzles.
-In any case, the [all syntax example](https://github.com/roc-lang/roc/blob/main/test/echo/all_syntax_test.roc) offers a great overview of the language.
+In any case, the [all syntax example](https://github.com/roc-lang/roc/blob/main/test/echo/all_syntax_test.roc) offers a great overview of the language. You can try the real compiler running in your browser below:
+
+<div class="roc-interactive front-page">
+remaining = |tasks|
+    tasks
+        .keep_if(|task| !task.done)
+        .map(|task| "☐ ${task.title}")
+        ->Str.join_with("\n")
+<!-- -->
+main! = |_| {
+    tasks = [
+        { title: "Learn Roc",       done: True },
+        { title: "Buy groceries",   done: True },
+        { title: "Write blog post", done: False },
+        { title: "Call mom",        done: False },
+    ]
+    echo!(remaining(tasks))
+    Ok({})
+}
+</div>
 
 To get started with the language, try the [tutorial](https://github.com/roc-lang/roc/blob/main/docs/mini-tutorial-new-compiler.md)!
 

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -161,7 +161,7 @@ function setupExample(div) {
   div.appendChild(outputArea);
 }
 
-// run the setup, whe the DOM is finished loading
+// run the setup, when the DOM is finished loading
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".roc-interactive").forEach(setupExample);
 });

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -1,0 +1,167 @@
+// main.js — Roc interactive examples (lazy-loads compiler on first Run click)
+"use strict";
+
+const utf8Decode = (bytes) => new TextDecoder().decode(bytes);
+const utf8Encode = (str) => new TextEncoder().encode(str);
+
+// All null until the user clicks "Run" for the first time.
+
+let wasmModule = null; // WebAssembly.Module
+let wasmInstance = null; // WebAssembly.Instance
+let wasmMemory = null; // WebAssembly.Memory
+let loadInProgress = null; // Promise | null — guards against concurrent loads
+
+// Every run creates a fresh { programOutput, compilerMessages } object
+// and stashes it here so the import callbacks can write into it.
+let runCapture = null;
+
+// Build a fresh imports object (needed for initial load & re-instantiation).
+function buildImports() {
+  return {
+    env: {
+      js_echo(ptr, len) {
+        if (runCapture) {
+          const slice = new Uint8Array(wasmMemory.buffer, ptr, len);
+          runCapture.programOutput += utf8Decode(slice);
+        }
+      },
+      js_stderr(ptr, len) {
+        if (runCapture) {
+          const slice = new Uint8Array(wasmMemory.buffer, ptr, len);
+          runCapture.compilerMessages += utf8Decode(slice);
+        }
+      },
+    },
+  };
+}
+
+async function loadCompiler() {
+  if (wasmInstance) return; // already loaded
+  if (loadInProgress) return loadInProgress; // another click is loading it
+
+  loadInProgress = (async () => {
+    const response = await fetch("echo.wasm");
+    const { module, instance } = await WebAssembly.instantiateStreaming(
+      response,
+      buildImports(),
+    );
+    wasmModule = module;
+    wasmInstance = instance;
+    wasmMemory = instance.exports.memory;
+    wasmInstance.exports.init();
+  })();
+
+  await loadInProgress;
+  loadInProgress = null;
+}
+
+async function recoverCompiler() {
+  try {
+    const instance = await WebAssembly.instantiate(wasmModule, buildImports());
+    wasmInstance = instance;
+    wasmMemory = instance.exports.memory;
+    wasmInstance.exports.init();
+  } catch (_) {
+    // best-effort — if recovery fails the next run will show the error
+  }
+}
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function setupExample(div) {
+  const source = div.textContent.trim();
+  div.textContent = "";
+
+  const textarea = document.createElement("textarea");
+  textarea.value = source;
+  textarea.rows = Math.min(source.split("\n").length + 2, 18);
+  textarea.spellcheck = false;
+  textarea.className = "roc-source";
+
+  // Keep Tab from leaving the textarea
+  textarea.addEventListener("keydown", (e) => {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      const ta = e.target;
+      const s = ta.selectionStart;
+      ta.value = ta.value.slice(0, s) + "\t" + ta.value.slice(ta.selectionEnd);
+      ta.selectionStart = ta.selectionEnd = s + 1;
+    }
+  });
+
+  const runButton = document.createElement("button");
+  runButton.textContent = "Run \u25b6";
+  runButton.className = "roc-run";
+
+  const outputArea = document.createElement("div");
+  outputArea.className = "roc-output";
+
+  runButton.addEventListener("click", async () => {
+    // ---- 1. lazy-load compiler on first click ----
+    if (!wasmInstance) {
+      outputArea.textContent = "Loading compiler\u2026";
+      try {
+        await loadCompiler();
+      } catch (err) {
+        outputArea.textContent = "Could not load the Roc compiler: " + err;
+        return;
+      }
+    }
+
+    // ---- 2. prepare ----
+    outputArea.textContent = "Running\u2026";
+    outputArea.classList.add("running");
+    runButton.disabled = true;
+
+    const captured = { programOutput: "", compilerMessages: "" };
+    runCapture = captured;
+    let trapped = false;
+
+    try {
+      wasmInstance.exports.init();
+
+      const encoded = utf8Encode(textarea.value);
+      const ptr = wasmInstance.exports.allocateBuffer(encoded.length);
+      if (!ptr) throw new Error("allocateBuffer returned null");
+      new Uint8Array(wasmMemory.buffer, ptr, encoded.length).set(encoded);
+
+      wasmInstance.exports.compileAndRun(ptr, encoded.length);
+    } catch (err) {
+      captured.compilerMessages +=
+        '<div class="report error"><h1>Compiler crashed</h1><pre>' +
+        escapeHtml(String(err)) +
+        "</pre></div>";
+      trapped = true;
+    }
+
+    runCapture = null;
+
+    // ---- 3. display results ----
+    let html = "";
+    if (captured.compilerMessages) html += captured.compilerMessages;
+    if (captured.programOutput) {
+      html += "<pre>" + escapeHtml(captured.programOutput) + "</pre>";
+    }
+    outputArea.innerHTML = html || "(no output)";
+    outputArea.classList.remove("running");
+
+    // ---- 4. recover from trap so later runs work ----
+    if (trapped) await recoverCompiler();
+
+    runButton.disabled = false;
+  });
+
+  div.appendChild(textarea);
+  div.appendChild(runButton);
+  div.appendChild(outputArea);
+}
+
+// run the setup, whe the DOM is finished loading
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".roc-interactive").forEach(setupExample);
+});

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -40,7 +40,7 @@ async function loadCompiler() {
   if (loadInProgress) return loadInProgress; // another click is loading it
 
   loadInProgress = (async () => {
-    const response = await fetch("echo.wasm");
+    const response = await fetch("echo.wasm", { priority: "low" });
     const { module, instance } = await WebAssembly.instantiateStreaming(
       response,
       buildImports(),
@@ -74,6 +74,12 @@ function escapeHtml(text) {
 }
 
 function setupExample(div) {
+  // The Run button is added statically in the markup (so it shows even before
+  // this script loads). Pull it out before reading the source so its label
+  // doesn't end up in the Roc code, then reuse it below.
+  const runButton = div.querySelector("button.roc-run");
+  runButton.remove();
+
   const source = div.textContent.trim();
   div.textContent = "";
 
@@ -94,9 +100,7 @@ function setupExample(div) {
     }
   });
 
-  const runButton = document.createElement("button");
   runButton.textContent = "Run \u25b6";
-  runButton.className = "roc-run";
 
   const outputArea = document.createElement("div");
   outputArea.className = "roc-output";
@@ -145,7 +149,10 @@ function setupExample(div) {
     let html = "";
     if (captured.compilerMessages) html += captured.compilerMessages;
     if (captured.programOutput) {
-      html += "<pre>" + escapeHtml(captured.programOutput) + "</pre>";
+      html +=
+        '<span class="roc-output-label">Output:\n</span><pre>' +
+        escapeHtml(captured.programOutput) +
+        "</pre>";
     }
     outputArea.innerHTML = html || "(no output)";
     outputArea.classList.remove("running");
@@ -164,4 +171,13 @@ function setupExample(div) {
 // run the setup, when the DOM is finished loading
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".roc-interactive").forEach(setupExample);
+
+  // Pre-download the compiler in the background at low priority so the first
+  // Run click is instant. Errors are ignored here — the click handler retries.
+  const preload = () => loadCompiler().catch(() => {});
+  if ("requestIdleCallback" in window) {
+    requestIdleCallback(preload);
+  } else {
+    preload();
+  }
 });

--- a/website/public/site.css
+++ b/website/public/site.css
@@ -1621,3 +1621,109 @@ code .dim {
 #rplf-h1 {
     color: var(--heading-color);
 }
+
+/* ---- interactive code widget ---- */
+
+.roc-interactive {
+    margin: 1.5em 0;
+    border: 1px solid #2d1b4e;
+}
+
+.roc-interactive.front-page {
+    display: block;
+    max-width: 720px;
+}
+
+.roc-interactive textarea.roc-source {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border: none;
+    padding: 0.75em;
+    font-family: monospace;
+    font-size: var(--font-size-normal);
+    tab-size: 4;
+    resize: vertical;
+    background: var(--dark-code-bg);
+    color: #e0d6f0;
+    border: 1px solid #ddd;
+}
+
+.roc-interactive button.roc-run {
+    display: block;
+    width: 100%;
+    padding: 0.4em;
+    border: none;
+    border-top: 1px solid #3d2a5e;
+    border-bottom: 1px solid #2d1b4e;
+    cursor: pointer;
+    font-size: var(--font-size-normal);
+    color: #fff !important;
+    background-color: rgb(124, 56, 245);
+    border: 4px solid #9b6bf2;
+}
+
+.roc-interactive button.roc-run:hover {
+    background: #9b6bf2;
+    border-color: #7c38f5;
+}
+
+.roc-interactive button.roc-run:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.roc-interactive .roc-output {
+    color: #b794e0;
+    font-family: monospace;
+    font-size: var(--font-size-normal);
+    white-space: pre-wrap;
+    border-top: 1px solid #2d1b4e;
+    min-height: 1.2em;
+}
+
+.roc-interactive .roc-output:empty {
+    display: none;
+}
+
+.roc-interactive .roc-output pre {
+    padding: 0.75em;
+    background-color: #151517;
+    margin: 0;
+    font: inherit;
+    white-space: pre-wrap;
+}
+
+/* ---- compiler diagnostics (emitted as HTML by js_stderr) ---- */
+
+.report {
+    border-left: 3px solid #555;
+    padding: 0.3em 0.6em;
+    margin: 0.3em 0;
+    font-size: 13px;
+}
+
+.report.error {
+    border-color: #e55;
+    background: #1f0f17;
+}
+.report.warning {
+    border-color: #c90;
+    background: #1f180f;
+}
+.report.info {
+    border-color: #48f;
+    background: #0f1722;
+}
+
+.report h1 {
+    font-size: 13px;
+    margin: 0 0 0.2em;
+}
+
+.report pre {
+    margin: 0.2em 0;
+    font-family: monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+}

--- a/website/public/site.css
+++ b/website/public/site.css
@@ -33,6 +33,7 @@
 
     --font-size-normal: 18px;
     --body-max-width: 1024px;
+    --action-btn-width: 120px;
     --dark-code-bg: #202746;
 
     /* Tutorial */
@@ -111,6 +112,10 @@ hr {
 }
 
 .btn-small {
+    display: inline-block;
+    box-sizing: border-box;
+    width: var(--action-btn-width);
+    text-align: center;
     white-space: nowrap;
     background: #7c38f5;
     border: 4px solid #9b6bf2;
@@ -257,6 +262,13 @@ h2 {
 
 #homepage-main h2 {
     margin-top: 60px; /* On the homepage, these need to be spaced out more. */
+}
+
+/* The Sponsors heading follows the Tutorial button; tighten its top margin to
+   1.5rem so the gap below that button matches the gap below the Run button
+   (the .roc-interactive widget's 1.5em ≈ 24px bottom margin). */
+#homepage-main h2#sponsors {
+    margin-top: 1.5rem;
 }
 
 #homepage-main #nav-home-link {
@@ -1574,6 +1586,15 @@ code .dim {
     #repl-arrow {
         display: none;
     }
+
+    /* Right-align the Tutorial button so it falls under the thumb on mobile.
+       (The Run button's override lives next to its base rule below, since that
+       rule comes later in the source and would otherwise win.) */
+    .btn-small {
+        display: block;
+        margin-left: auto;
+        margin-right: 0;
+    }
 }
 
 #gh-logo {
@@ -1626,7 +1647,6 @@ code .dim {
 
 .roc-interactive {
     margin: 1.5em 0;
-    border: 1px solid #2d1b4e;
 }
 
 .roc-interactive.front-page {
@@ -1649,17 +1669,30 @@ code .dim {
     border: 1px solid #ddd;
 }
 
-.roc-interactive button.roc-run {
+/* Shown only when JS is disabled — the script replaces it with the textarea above. */
+.roc-interactive pre.roc-source {
     display: block;
-    width: 100%;
-    padding: 0.4em;
-    border: none;
-    border-top: 1px solid #3d2a5e;
-    border-bottom: 1px solid #2d1b4e;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0.75em;
+    font-family: monospace;
+    font-size: var(--font-size-normal);
+    tab-size: 4;
+    background: var(--dark-code-bg);
+    color: #e0d6f0;
+    border: 1px solid #ddd;
+    overflow-x: auto;
+}
+
+.roc-interactive button.roc-run {
+    margin: 16px 0;
+    box-sizing: border-box;
+    width: var(--action-btn-width);
+    padding: 12px;
     cursor: pointer;
     font-size: var(--font-size-normal);
     color: #fff !important;
-    background-color: rgb(124, 56, 245);
+    background: #7c38f5;
     border: 4px solid #9b6bf2;
 }
 
@@ -1678,12 +1711,15 @@ code .dim {
     font-family: monospace;
     font-size: var(--font-size-normal);
     white-space: pre-wrap;
-    border-top: 1px solid #2d1b4e;
     min-height: 1.2em;
 }
 
 .roc-interactive .roc-output:empty {
     display: none;
+}
+
+.roc-interactive .roc-output-label {
+    color: var(--text-color);
 }
 
 .roc-interactive .roc-output pre {
@@ -1692,6 +1728,16 @@ code .dim {
     margin: 0;
     font: inherit;
     white-space: pre-wrap;
+}
+
+/* Right-align the Run button so it falls under the thumb on mobile. Defined
+   here (after the base .roc-run rule) so it wins on source order. */
+@media only screen and (max-width: 767px) {
+    .roc-interactive button.roc-run {
+        display: block;
+        margin-left: auto;
+        margin-right: 0;
+    }
 }
 
 /* ---- compiler diagnostics (emitted as HTML by js_stderr) ---- */

--- a/website/static_site_gen.roc
+++ b/website/static_site_gen.roc
@@ -5,7 +5,7 @@ app [main!] {
 import pf.SSG
 #import pf.Types
 import pf.Html exposing [header, nav, div, link, text, a, span, html, head, body, meta, script, footer]
-import pf.Html.Attributes exposing [id, aria_label, aria_hidden, title, href, class, rel, content, lang, charset, name, color]
+import pf.Html.Attributes exposing [id, aria_label, aria_hidden, title, href, class, rel, content, lang, charset, name, color, src]
 #import "content/tutorial.md" as tutorial_markdown : Str
 
 #import InteractiveRocExample
@@ -130,6 +130,7 @@ view = |page_path_str, html_content|
             # hidden via CSS using a .no-js selector will apply to the initial layout
             # of the body instead of having a flash of content that immediately gets hidden.
             script([], [text("document.documentElement.className = document.documentElement.className.replace('no-js', '');")]),
+            script([src("/compiler.js")], []),
         ]),
         body(body_attrs, [
             view_navbar(page_path_str),


### PR DESCRIPTION
The goal of this PR is to introduce an interactive example widget in the front page, so users can try and play with roc.

This PR adds the following things:

- download the latest roc compiler wasm from the nightlies during website build
- a js script that replaces every HTML element with the class `roc-interactive` with a text area, run button and output
- the wasm compiler is lazy loaded on first click on the run button
- a code example of roc on the front page
- css for the code widget

NOTE: Running of the WASM compiler currently fails with an OutOfMemoryError, this error is currently discussed in Zulip, let me know if i should open an issue to the roc repo for this. As soon as the error is fixed, with a new nightly build and the website is rebuilt, the code widget should start working

Let me know what you think :)