### PR TITLE
Add ROC_INSTALL_DIR env var for install_roc.sh and install_roc.ps1

### DIFF
--- a/website/public/install_roc.ps1
+++ b/website/public/install_roc.ps1
@@ -86,12 +86,24 @@ if ($actualHash -ne $ExpectedSha.ToLower()) {
 # ---- Extract ----
 Write-Host "Step 3: Extracting files..."
 
-$installDirName = "roc_nightly-$Platform`_$ArchName-$VersionDate-$BuildId"
-$installDir     = Join-Path $PWD $installDirName
+$extractDirName = "roc_nightly-$Platform`_$ArchName-$VersionDate-$BuildId"
+$extractDir     = Join-Path $PWD $extractDirName
 
 Expand-Archive -Path $downloadPath -DestinationPath $PWD -Force
 
-Write-Host "Roc was extracted to: $installDir"
+Write-Host "Roc was extracted to: $extractDir"
+
+if ($env:ROC_INSTALL_DIR) {
+    $targetDir = New-Item -ItemType Directory -Path $env:ROC_INSTALL_DIR -Force
+    $rocExePath = Join-Path $extractDir "roc.exe"
+    Copy-Item -Path $rocExePath -Destination $env:ROC_INSTALL_DIR -Force    
+    Write-Host "Roc executable was copied to: $($env:ROC_INSTALL_DIR)"
+    $installDir = $targetDir.FullName
+}
+else {
+    $installDir = $extractDir
+}
+
 Write-Host ""
 
 Write-Host @"

--- a/website/public/install_roc.sh
+++ b/website/public/install_roc.sh
@@ -125,8 +125,17 @@ fi
 echo "📦 Step 3: Extracting files..."
 tar -xf "$FILE"
 DIR_NAME="roc_nightly-${PLATFORM}_${ARCH_NAME}-${VERSION_DATE}-${BUILD_ID}"
-INSTALL_DIR="$PWD/$DIR_NAME"
-echo "✅ Roc was extracted to: $INSTALL_DIR"
+EXTRACT_DIR="$PWD/$DIR_NAME"
+echo "✅ Roc was extracted to: $EXTRACT_DIR"
+
+if [ -n "$ROC_INSTALL_DIR" ]; then
+    mkdir -p "$ROC_INSTALL_DIR"
+    cp "$EXTRACT_DIR/roc" "$ROC_INSTALL_DIR"
+    echo "✅ Roc executable was copied to: $ROC_INSTALL_DIR"
+    INSTALL_DIR=$(realpath "$ROC_INSTALL_DIR")
+else
+    INSTALL_DIR="$EXTRACT_DIR"
+fi
 
 # ---- Explain PATH in beginner-friendly terms ----
 cat <<EOF

--- a/website/public/install_roc.sh
+++ b/website/public/install_roc.sh
@@ -128,7 +128,7 @@ DIR_NAME="roc_nightly-${PLATFORM}_${ARCH_NAME}-${VERSION_DATE}-${BUILD_ID}"
 EXTRACT_DIR="$PWD/$DIR_NAME"
 echo "✅ Roc was extracted to: $EXTRACT_DIR"
 
-if [ -n "$ROC_INSTALL_DIR" ]; then
+if [ -n "${ROC_INSTALL_DIR:-}" ]; then
     mkdir -p "$ROC_INSTALL_DIR"
     cp "$EXTRACT_DIR/roc" "$ROC_INSTALL_DIR"
     echo "✅ Roc executable was copied to: $ROC_INSTALL_DIR"


### PR DESCRIPTION
This PR adds the option to set the `ROC_INSTALL_DIR` environment variable when running the `install_roc.sh`:

```bash
export ROC_INSTALL_DIR=~/.roc/bin
export ROC_CONTINUE_IF_STALE=y
export ROC_ADD_TO_PATH=n
curl --proto '=https' --tlsv1.2 -sSf https://roc-lang.org/install_roc.sh | sh
```

On Windows, it looks like this:

```powershell
$env:ROC_INSTALL_DIR="C:\Roc"
$env:ROC_CONTINUE_IF_STALE=y
$env:ROC_ADD_TO_PATH=n
powershell -ExecutionPolicy Bypass  # if needed
irm https://roc-lang.org/install_roc.ps1 | iex
```

Since the tarball contains more than just the executable (i.e., it also contains `LICENSE` and `legal_details`), and since the `roc` (or `roc.exe`) executable is standalone, I preferred to simply copy it to the `ROC_INSTALL_DIR` rather than untar the tarball directly in that directory.

Tested on MacOS, Linux, and Windows.