### PR TITLE
Add homepage Roc syntax highlighting

### DIFF
--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -171,88 +171,76 @@ function renderTerminalBlock(text) {
   return `<pre class="roc-terminal">${renderAnsiTerminal(text)}</pre>`;
 }
 
-const ROC_TOKEN_NAMES = `
-  EndOfFile Float StringStart StringEnd MultilineStringStart StringPart MalformedStringPart
-  SingleQuote MalformedSingleQuote Int MalformedNumberBadSuffix MalformedNumberUnicodeSuffix
-  MalformedNumberNoDigits MalformedNumberNoExponentDigits MalformedInvalidUnicodeEscapeSequence
-  MalformedInvalidEscapeSequence UpperIdent LowerIdent MalformedUnicodeIdent Underscore
-  DotLowerIdent DotInt DotUpperIdent NoSpaceDotInt NoSpaceDotLowerIdent NoSpaceDotUpperIdent
-  MalformedDotUnicodeIdent MalformedNoSpaceDotUnicodeIdent NamedUnderscore
-  MalformedNamedUnderscoreUnicode OpaqueName MalformedOpaqueNameUnicode
-  MalformedOpaqueNameWithoutName OpenRound CloseRound OpenSquare CloseSquare OpenCurly
-  CloseCurly OpenStringInterpolation CloseStringInterpolation NoSpaceOpenRound OpPlus OpStar
-  OpPizza OpAssign OpBinaryMinus OpUnaryMinus OpNotEquals OpBang OpAnd OpAmpersand OpQuestion
-  OpDoubleQuestion OpOr OpBar OpDoubleSlash OpSlash OpPercent OpCaret OpGreaterThanOrEq
-  OpGreaterThan OpLessThanOrEq OpBackArrow OpLessThan OpDoubleDotLessThan OpDoubleDotEquals
-  OpEquals OpColonEqual OpDoubleColon NoSpaceOpQuestion Comma Dot DoubleDot TripleDot DotStar
-  OpColon OpArrow OpFatArrow OpBackslash KwApp KwAs KwCrash KwDbg KwElse KwExpect KwExposes
-  KwExposing KwFor KwGenerates KwHas KwHosted KwIf KwImplements KwImport KwImports KwIn
-  KwInterface KwMatch KwModule KwPackage KwPackages KwPlatform KwProvides KwRequires KwReturn
-  KwTargets KwVar KwWhere KwWhile KwWith KwBreak MalformedUnknownToken
-`.trim().split(/\s+/);
+const TOK_CLASS = [
+  null,
+  "upperident",
+  "lowerident",
+  "literal",
+  "string",
+  "keyword",
+  "punctuation",
+  "delimiter",
+  "op",
+  "error",
+];
+const C_MASK = 15;
+const C_UPPER = 1;
+const C_LOWER = 2;
+const C_LITERAL = 3;
+const C_STRING = 4;
+const C_KEYWORD = 5;
+const C_PUNCT = 6;
+const C_DELIM = 7;
+const C_OP = 8;
+const C_ERROR = 9;
+const F_EXPR_END = 16;
+const F_FIELD_PREFIX = 32;
+const F_FIELD_NAME = 64;
+const F_DOT_PREFIX = 128;
+const F_DOTDOT_PREFIX = 256;
+const F_COLON = 512;
 
-const ROC_TOKEN = Object.freeze(Object.fromEntries(ROC_TOKEN_NAMES.map((name) => [name, name])));
-
-function rocTokenSet(names) {
-  return new Set(names.trim().split(/\s+/).map((name) => ROC_TOKEN[name]));
-}
-
-function tokenClass(className, names) {
-  return names.trim().split(/\s+/).map((name) => [ROC_TOKEN[name], className]);
-}
+const T_NONE = 0;
+const T_ERROR = C_ERROR;
+const T_ERROR_END = C_ERROR | F_EXPR_END;
+const T_UPPER = C_UPPER | F_EXPR_END;
+const T_LOWER = C_LOWER | F_EXPR_END | F_FIELD_NAME;
+const T_LITERAL = C_LITERAL | F_EXPR_END;
+const T_STRING = C_STRING;
+const T_STRING_END = C_STRING | F_EXPR_END;
+const T_KEYWORD = C_KEYWORD;
+const T_KEYWORD_END = C_KEYWORD | F_EXPR_END;
+const T_PUNCT = C_PUNCT;
+const T_PUNCT_END = C_PUNCT | F_EXPR_END;
+const T_FIELD_PREFIX = C_PUNCT | F_FIELD_PREFIX;
+const T_DELIM = C_DELIM;
+const T_DELIM_END = C_DELIM | F_EXPR_END;
+const T_OP = C_OP;
+const T_OP_FIELD_PREFIX = C_OP | F_FIELD_PREFIX;
+const T_COLON = C_OP | F_COLON;
+const T_DOT_LOWER = C_LOWER | F_EXPR_END | F_DOT_PREFIX;
+const T_DOT_UPPER = C_UPPER | F_EXPR_END | F_DOT_PREFIX;
+const T_DOT_LITERAL = C_LITERAL | F_EXPR_END | F_DOT_PREFIX;
+const T_DOT_OP = C_OP | F_DOT_PREFIX;
+const T_DOT_ERROR = C_ERROR | F_EXPR_END | F_DOT_PREFIX;
+const T_DOTDOT_OP = C_OP | F_DOTDOT_PREFIX;
 
 const ROC_KEYWORDS = new Map([
-  ["and", ROC_TOKEN.OpAnd],
-  ["or", ROC_TOKEN.OpOr],
+  ["and", T_OP],
+  ["or", T_OP],
   ..."app as crash dbg else expect exposes exposing for generates has hosted if implements import imports in interface match module package packages platform provides requires return targets var where while with break"
     .split(/\s+/)
-    .map((word) => [word, ROC_TOKEN[`Kw${word[0].toUpperCase()}${word.slice(1)}`]]),
+    .map((word) => [word, T_KEYWORD]),
 ]);
 
 const ROC_NUMBER_SUFFIXES = new Set("dec f32 f64 i128 i16 i32 i64 i8 nat u128 u16 u32 u64 u8".split(" "));
 
-const ROC_MALFORMED_TOKENS = rocTokenSet(`
-  MalformedDotUnicodeIdent MalformedInvalidEscapeSequence MalformedInvalidUnicodeEscapeSequence
-  MalformedNamedUnderscoreUnicode MalformedNoSpaceDotUnicodeIdent MalformedNumberBadSuffix
-  MalformedNumberNoDigits MalformedNumberNoExponentDigits MalformedNumberUnicodeSuffix
-  MalformedOpaqueNameUnicode MalformedOpaqueNameWithoutName MalformedUnicodeIdent
-  MalformedUnknownToken MalformedSingleQuote MalformedStringPart
-`);
-
-const ROC_EXPR_END_TOKENS = rocTokenSet(`
-  LowerIdent UpperIdent MalformedUnicodeIdent NamedUnderscore MalformedNamedUnderscoreUnicode
-  OpaqueName MalformedOpaqueNameUnicode DotLowerIdent DotUpperIdent DotInt NoSpaceDotLowerIdent
-  NoSpaceDotUpperIdent NoSpaceDotInt MalformedDotUnicodeIdent MalformedNoSpaceDotUnicodeIdent
-  Int Float MalformedNumberBadSuffix MalformedNumberUnicodeSuffix MalformedNumberNoDigits
-  MalformedNumberNoExponentDigits CloseRound CloseSquare CloseCurly CloseStringInterpolation
-  StringEnd SingleQuote MalformedSingleQuote
-`);
-
-const ROC_RECORD_FIELD_PREFIXES = rocTokenSet("OpenCurly Comma OpAmpersand OpBackArrow");
-const ROC_RECORD_FIELD_NAMES = rocTokenSet("LowerIdent NamedUnderscore");
-const ROC_DOT_PREFIXED_TOKENS = rocTokenSet(`
-  DotLowerIdent DotUpperIdent DotInt NoSpaceDotLowerIdent NoSpaceDotUpperIdent NoSpaceDotInt
-  MalformedDotUnicodeIdent MalformedNoSpaceDotUnicodeIdent DotStar
-`);
-
-const ROC_TOKEN_CLASSES = new Map([
-  ...tokenClass("upperident", "UpperIdent DotUpperIdent NoSpaceDotUpperIdent OpaqueName"),
-  ...tokenClass("lowerident", "LowerIdent DotLowerIdent NoSpaceDotLowerIdent NamedUnderscore"),
-  ...tokenClass("literal", "Int Float DotInt NoSpaceDotInt"),
-  ...tokenClass("string", "StringStart StringEnd MultilineStringStart StringPart SingleQuote"),
-  ...tokenClass("keyword", "OpenStringInterpolation CloseStringInterpolation"),
-  ...tokenClass("punctuation", "NoSpaceOpenRound OpenRound CloseRound OpenCurly CloseCurly Comma Dot DoubleDot TripleDot"),
-  ...tokenClass("delimiter", "OpenSquare CloseSquare"),
-  ...tokenClass("op",
-    `OpPlus OpStar OpPizza OpAssign OpBinaryMinus OpUnaryMinus OpNotEquals OpBang OpAnd OpAmpersand
-    OpQuestion OpDoubleQuestion OpOr OpBar OpDoubleSlash OpSlash OpPercent OpCaret OpGreaterThanOrEq
-    OpGreaterThan OpLessThanOrEq OpBackArrow OpLessThan OpDoubleDotLessThan OpDoubleDotEquals
-    OpEquals OpColonEqual OpDoubleColon NoSpaceOpQuestion DotStar OpColon OpArrow OpFatArrow OpBackslash`,
-  ),
-]);
+function isRocTokenError(tok) {
+  return (tok & C_MASK) === C_ERROR;
+}
 
 function updateIfNotMalformed(tok, next) {
-  return ROC_MALFORMED_TOKENS.has(tok) ? tok : next;
+  return isRocTokenError(tok) ? tok : next;
 }
 
 function isAsciiLower(c) {
@@ -341,28 +329,28 @@ class RocCursor {
     const initialDigit = this.buf[this.pos];
     this.pos += 1;
 
-    let tok = ROC_TOKEN.Int;
+    let tok = T_LITERAL;
     if (initialDigit === 48) {
       while (true) {
         const c = this.peek() ?? 0;
         if (c === 120 || c === 88) {
           this.pos += 1;
           if (!this.chompIntegerBase16()) {
-            tok = ROC_TOKEN.MalformedNumberNoDigits;
+            tok = T_ERROR_END;
           }
           tok = this.chompNumberSuffix(tok);
           break;
         } else if (c === 111 || c === 79) {
           this.pos += 1;
           if (!this.chompIntegerBase8()) {
-            tok = ROC_TOKEN.MalformedNumberNoDigits;
+            tok = T_ERROR_END;
           }
           tok = this.chompNumberSuffix(tok);
           break;
         } else if (c === 98 || c === 66) {
           this.pos += 1;
           if (!this.chompIntegerBase2()) {
-            tok = ROC_TOKEN.MalformedNumberNoDigits;
+            tok = T_ERROR_END;
           }
           tok = this.chompNumberSuffix(tok);
           break;
@@ -423,17 +411,17 @@ class RocCursor {
 
     const start = this.pos;
     if (!this.chompIdentGeneral()) {
-      return updateIfNotMalformed(hypothesis, ROC_TOKEN.MalformedNumberUnicodeSuffix);
+      return updateIfNotMalformed(hypothesis, T_ERROR_END);
     }
     const suffix = utf8Decode(this.buf.subarray(start, this.pos));
     if (!ROC_NUMBER_SUFFIXES.has(suffix)) {
-      return updateIfNotMalformed(hypothesis, ROC_TOKEN.MalformedNumberBadSuffix);
+      return updateIfNotMalformed(hypothesis, T_ERROR_END);
     }
     return hypothesis;
   }
 
   chompNumberBase10() {
-    let tokenType = ROC_TOKEN.Int;
+    let tokenType = T_LITERAL;
     this.chompIntegerBase10();
     if (
       (this.peek() ?? 0) === 46 &&
@@ -443,15 +431,15 @@ class RocCursor {
     ) {
       this.pos += 1;
       this.chompIntegerBase10();
-      tokenType = ROC_TOKEN.Float;
+      tokenType = T_LITERAL;
     }
 
     const hasExponent = this.chompExponent();
     if (hasExponent === "EmptyExponent") {
-      return ROC_TOKEN.MalformedNumberNoExponentDigits;
+      return T_ERROR_END;
     }
     if (hasExponent) {
-      tokenType = ROC_TOKEN.Float;
+      tokenType = T_LITERAL;
     }
     return tokenType;
   }
@@ -523,10 +511,10 @@ class RocCursor {
   chompIdentLower() {
     const start = this.pos;
     if (!this.chompIdentGeneral()) {
-      return ROC_TOKEN.MalformedUnicodeIdent;
+      return T_ERROR_END;
     }
     const ident = utf8Decode(this.buf.subarray(start, this.pos));
-    return ROC_KEYWORDS.get(ident) ?? ROC_TOKEN.LowerIdent;
+    return ROC_KEYWORDS.get(ident) ?? T_LOWER;
   }
 
   chompIdentGeneral() {
@@ -634,7 +622,7 @@ class RocCursor {
 
       if (state === "Empty") {
         if (c === 39) {
-          return ROC_TOKEN.MalformedSingleQuote;
+          return T_ERROR_END;
         }
         if (c === 92) {
           state = "Enough";
@@ -648,19 +636,19 @@ class RocCursor {
         }
       } else if (state === "Enough") {
         if (c === 39) {
-          return ROC_TOKEN.SingleQuote;
+          return T_STRING_END;
         }
         state = "TooLong";
       } else if (state === "TooLong") {
         if (c === 39) {
-          return ROC_TOKEN.MalformedSingleQuote;
+          return T_ERROR_END;
         }
       } else if (state === "Invalid" && c === 39) {
-        return ROC_TOKEN.MalformedSingleQuote;
+        return T_ERROR_END;
       }
     }
 
-    return ROC_TOKEN.MalformedSingleQuote;
+    return T_ERROR_END;
   }
 
   chompUTF8CodepointWithValidation() {
@@ -732,124 +720,124 @@ class RocTokenizer {
       } else if (b === 33) {
         if (this.cursor.peekAt(1) === 61) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpNotEquals, start);
+          this.pushToken(T_OP, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpBang, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 38) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpAmpersand, start);
+        this.pushToken(T_OP_FIELD_PREFIX, start);
       } else if (b === 44) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.Comma, start);
+        this.pushToken(T_FIELD_PREFIX, start);
       } else if (b === 63) {
         if (this.cursor.peekAt(1) === 63) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpDoubleQuestion, start);
+          this.pushToken(T_OP, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(sp ? ROC_TOKEN.OpQuestion : ROC_TOKEN.NoSpaceOpQuestion, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 124) {
         if (this.cursor.peekAt(1) === 62) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpPizza, start);
+          this.pushToken(T_OP, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpBar, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 43) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpPlus, start);
+        this.pushToken(T_OP, start);
       } else if (b === 42) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpStar, start);
+        this.pushToken(T_OP, start);
       } else if (b === 47) {
         if (this.cursor.peekAt(1) === 47) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpDoubleSlash, start);
+          this.pushToken(T_OP, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpSlash, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 92) {
         if (this.cursor.peekAt(1) === 92) {
           this.tokenizeMultilineStringLiteral();
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpBackslash, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 37) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpPercent, start);
+        this.pushToken(T_OP, start);
       } else if (b === 94) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpCaret, start);
+        this.pushToken(T_OP, start);
       } else if (b === 62) {
         if (this.cursor.peekAt(1) === 61) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpGreaterThanOrEq, start);
+          this.pushToken(T_OP, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpGreaterThan, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 60) {
         if (this.cursor.peekAt(1) === 61) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpLessThanOrEq, start);
+          this.pushToken(T_OP, start);
         } else if (this.cursor.peekAt(1) === 45) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpBackArrow, start);
+          this.pushToken(T_OP_FIELD_PREFIX, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpLessThan, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 61) {
         if (this.cursor.peekAt(1) === 61) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpEquals, start);
+          this.pushToken(T_OP, start);
         } else if (this.cursor.peekAt(1) === 62) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpFatArrow, start);
+          this.pushToken(T_OP, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpAssign, start);
+          this.pushToken(T_OP, start);
         }
       } else if (b === 58) {
         if (this.cursor.peekAt(1) === 61) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpColonEqual, start);
+          this.pushToken(T_OP, start);
         } else if (this.cursor.peekAt(1) === 58) {
           this.cursor.pos += 2;
-          this.pushToken(ROC_TOKEN.OpDoubleColon, start);
+          this.pushToken(T_OP, start);
         } else {
           this.cursor.pos += 1;
-          this.pushToken(ROC_TOKEN.OpColon, start);
+          this.pushToken(T_COLON, start);
         }
       } else if (b === 40) {
         this.cursor.pos += 1;
-        this.pushToken(sp ? ROC_TOKEN.OpenRound : ROC_TOKEN.NoSpaceOpenRound, start);
+        this.pushToken(T_PUNCT, start);
       } else if (b === 91) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpenSquare, start);
+        this.pushToken(T_DELIM, start);
       } else if (b === 123) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpenCurly, start);
+        this.pushToken(T_FIELD_PREFIX, start);
       } else if (b === 41) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.CloseRound, start);
+        this.pushToken(T_PUNCT_END, start);
       } else if (b === 93) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.CloseSquare, start);
+        this.pushToken(T_DELIM_END, start);
       } else if (b === 125) {
         this.cursor.pos += 1;
         if (this.stringInterpolationStack.length > 0) {
           const last = this.stringInterpolationStack.pop();
-          this.pushToken(ROC_TOKEN.CloseStringInterpolation, start);
+          this.pushToken(T_KEYWORD_END, start);
           this.tokenizeStringLikeLiteralBody(last);
         } else {
-          this.pushToken(ROC_TOKEN.CloseCurly, start);
+          this.pushToken(T_PUNCT_END, start);
         }
       } else if (b === 95) {
         this.tokenizeUnderscore(start);
@@ -864,9 +852,9 @@ class RocTokenizer {
         const tag = this.cursor.chompIdentLower();
         this.pushToken(tag, start);
       } else if (isAsciiUpper(b)) {
-        let tag = ROC_TOKEN.UpperIdent;
+        let tag = T_UPPER;
         if (!this.cursor.chompIdentGeneral()) {
-          tag = ROC_TOKEN.MalformedUnicodeIdent;
+          tag = T_ERROR_END;
         }
         this.pushToken(tag, start);
       } else if (b === 39) {
@@ -876,14 +864,14 @@ class RocTokenizer {
         this.tokenizeStringLikeLiteral();
       } else if (b >= 0x80) {
         this.cursor.chompIdentGeneral();
-        this.pushToken(ROC_TOKEN.MalformedUnicodeIdent, start);
+        this.pushToken(T_ERROR_END, start);
       } else {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.MalformedUnknownToken, start);
+        this.pushToken(T_ERROR, start);
       }
     }
 
-    this.pushToken(ROC_TOKEN.EndOfFile, this.cursor.pos);
+    this.pushToken(T_NONE, this.cursor.pos);
     return {
       tokens: this.tokens,
       comments: this.cursor.commentRanges,
@@ -895,52 +883,52 @@ class RocTokenizer {
     const next = this.cursor.peekAt(1);
     if (next == null) {
       this.cursor.pos += 1;
-      this.pushToken(ROC_TOKEN.Dot, start);
+      this.pushToken(T_PUNCT, start);
     } else if (next === 46) {
       if (this.cursor.peekAt(2) === 46) {
         this.cursor.pos += 3;
-        this.pushToken(ROC_TOKEN.TripleDot, start);
+        this.pushToken(T_PUNCT, start);
       } else if (this.cursor.peekAt(2) === 60) {
         this.cursor.pos += 3;
-        this.pushToken(ROC_TOKEN.OpDoubleDotLessThan, start);
+        this.pushToken(T_DOTDOT_OP, start);
       } else if (this.cursor.peekAt(2) === 61) {
         this.cursor.pos += 3;
-        this.pushToken(ROC_TOKEN.OpDoubleDotEquals, start);
+        this.pushToken(T_DOTDOT_OP, start);
       } else {
         this.cursor.pos += 2;
-        this.pushToken(ROC_TOKEN.DoubleDot, start);
+        this.pushToken(T_PUNCT, start);
       }
     } else if (isAsciiDigit(next)) {
       this.cursor.pos += 1;
       this.cursor.chompInteger();
-      this.pushToken(sp ? ROC_TOKEN.DotInt : ROC_TOKEN.NoSpaceDotInt, start);
+      this.pushToken(T_DOT_LITERAL, start);
     } else if (isAsciiLower(next)) {
-      let tag = sp ? ROC_TOKEN.DotLowerIdent : ROC_TOKEN.NoSpaceDotLowerIdent;
+      let tag = T_DOT_LOWER;
       this.cursor.pos += 1;
       if (!this.cursor.chompIdentGeneral()) {
-        tag = ROC_TOKEN.MalformedDotUnicodeIdent;
+        tag = T_DOT_ERROR;
       }
       this.pushToken(tag, start);
     } else if (isAsciiUpper(next)) {
-      let tag = sp ? ROC_TOKEN.DotUpperIdent : ROC_TOKEN.NoSpaceDotUpperIdent;
+      let tag = T_DOT_UPPER;
       this.cursor.pos += 1;
       if (!this.cursor.chompIdentGeneral()) {
-        tag = ROC_TOKEN.MalformedDotUnicodeIdent;
+        tag = T_DOT_ERROR;
       }
       this.pushToken(tag, start);
     } else if (next >= 0x80 && next <= 0xff) {
       this.cursor.pos += 1;
       this.cursor.chompIdentGeneral();
-      this.pushToken(ROC_TOKEN.MalformedDotUnicodeIdent, start);
+      this.pushToken(T_DOT_ERROR, start);
     } else if (next === 123) {
       this.cursor.pos += 1;
-      this.pushToken(ROC_TOKEN.Dot, start);
+      this.pushToken(T_PUNCT, start);
     } else if (next === 42) {
       this.cursor.pos += 2;
-      this.pushToken(ROC_TOKEN.DotStar, start);
+      this.pushToken(T_DOT_OP, start);
     } else {
       this.cursor.pos += 1;
-      this.pushToken(ROC_TOKEN.Dot, start);
+      this.pushToken(T_PUNCT, start);
     }
   }
 
@@ -948,18 +936,18 @@ class RocTokenizer {
     const next = this.cursor.peekAt(1);
     if (next == null) {
       this.cursor.pos += 1;
-      this.pushToken(ROC_TOKEN.OpUnaryMinus, start);
+      this.pushToken(T_OP, start);
     } else if (next === 62) {
       this.cursor.pos += 2;
-      this.pushToken(ROC_TOKEN.OpArrow, start);
+      this.pushToken(T_OP, start);
     } else if (next === 32 || next === 9 || next === 10 || next === 13 || next === 35) {
       this.cursor.pos += 1;
-      this.pushToken(ROC_TOKEN.OpBinaryMinus, start);
+      this.pushToken(T_OP, start);
     } else if (isAsciiDigit(next)) {
       const prev = this.lastTokenTag();
-      if (!sp && prev != null && ROC_EXPR_END_TOKENS.has(prev)) {
+      if (!sp && prev != null && (prev & F_EXPR_END) !== 0) {
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.OpBinaryMinus, start);
+        this.pushToken(T_OP, start);
       } else {
         this.cursor.pos += 1;
         const tag = this.cursor.chompNumber();
@@ -967,27 +955,27 @@ class RocTokenizer {
       }
     } else {
       this.cursor.pos += 1;
-      this.pushToken(canFollowUnaryMinus(next) ? ROC_TOKEN.OpUnaryMinus : ROC_TOKEN.OpBinaryMinus, start);
+      this.pushToken(T_OP, start);
     }
   }
 
   tokenizeUnderscore(start) {
     const next = this.cursor.peekAt(1);
     if (next != null && (isAsciiLower(next) || isAsciiUpper(next) || isAsciiDigit(next))) {
-      let tag = ROC_TOKEN.NamedUnderscore;
+      let tag = T_LOWER;
       this.cursor.pos += 2;
       if (!this.cursor.chompIdentGeneral()) {
-        tag = ROC_TOKEN.MalformedNamedUnderscoreUnicode;
+        tag = T_ERROR_END;
       }
       this.pushToken(tag, start);
     } else {
       this.cursor.pos += 1;
-      this.pushToken(ROC_TOKEN.Underscore, start);
+      this.pushToken(T_NONE, start);
     }
   }
 
   tokenizeOpaqueName(start) {
-    let tok = ROC_TOKEN.OpaqueName;
+    let tok = T_UPPER;
     const next = this.cursor.peekAt(1);
     if (
       next != null &&
@@ -995,10 +983,10 @@ class RocTokenizer {
     ) {
       this.cursor.pos += 1;
       if (!this.cursor.chompIdentGeneral()) {
-        tok = ROC_TOKEN.MalformedOpaqueNameUnicode;
+        tok = T_ERROR_END;
       }
     } else {
-      tok = ROC_TOKEN.MalformedOpaqueNameWithoutName;
+      tok = T_ERROR;
       this.cursor.pos += 1;
     }
     this.pushToken(tok, start);
@@ -1007,22 +995,22 @@ class RocTokenizer {
   tokenizeDollar(start) {
     const next = this.cursor.peekAt(1);
     if (next != null && isAsciiLower(next)) {
-      let tag = ROC_TOKEN.LowerIdent;
+      let tag = T_LOWER;
       this.cursor.pos += 1;
       if (!this.cursor.chompIdentGeneral()) {
-        tag = ROC_TOKEN.MalformedUnicodeIdent;
+        tag = T_ERROR_END;
       }
       this.pushToken(tag, start);
     } else if (next != null && isAsciiUpper(next)) {
-      let tag = ROC_TOKEN.UpperIdent;
+      let tag = T_UPPER;
       this.cursor.pos += 1;
       if (!this.cursor.chompIdentGeneral()) {
-        tag = ROC_TOKEN.MalformedUnicodeIdent;
+        tag = T_ERROR_END;
       }
       this.pushToken(tag, start);
     } else {
       this.cursor.pos += 1;
-      this.pushToken(ROC_TOKEN.MalformedUnknownToken, start);
+      this.pushToken(T_ERROR, start);
     }
   }
 
@@ -1033,9 +1021,9 @@ class RocTokenizer {
     if (this.cursor.peek() === 34 && this.cursor.peekAt(1) === 34) {
       this.cursor.pos += 2;
       kind = "multi_line";
-      this.pushToken(ROC_TOKEN.MultilineStringStart, start);
+      this.pushToken(T_STRING, start);
     } else {
-      this.pushToken(ROC_TOKEN.StringStart, start);
+      this.pushToken(T_STRING, start);
     }
     this.tokenizeStringLikeLiteralBody(kind);
   }
@@ -1043,38 +1031,38 @@ class RocTokenizer {
   tokenizeMultilineStringLiteral() {
     const start = this.cursor.pos;
     this.cursor.pos += 2;
-    this.pushToken(ROC_TOKEN.MultilineStringStart, start);
+    this.pushToken(T_STRING, start);
     this.tokenizeStringLikeLiteralBody("multi_line");
   }
 
   tokenizeStringLikeLiteralBody(kind) {
     const start = this.cursor.pos;
-    let stringPartTag = ROC_TOKEN.StringPart;
+    let stringPartTag = T_STRING;
     while (this.cursor.pos < this.cursor.buf.length) {
       const c = this.cursor.buf[this.cursor.pos];
       if (c === 36 && this.cursor.peekAt(1) === 123) {
         this.pushToken(stringPartTag, start);
         const dollarStart = this.cursor.pos;
         this.cursor.pos += 2;
-        this.pushToken(ROC_TOKEN.OpenStringInterpolation, dollarStart);
+        this.pushToken(T_KEYWORD, dollarStart);
         this.stringInterpolationStack.push(kind);
         return;
       } else if (c === 10) {
         this.pushToken(stringPartTag, start);
         if (kind === "single_line") {
-          this.pushToken(ROC_TOKEN.StringEnd, this.cursor.pos);
+          this.pushToken(T_STRING_END, this.cursor.pos);
         }
         return;
       } else if (kind === "single_line" && c === 34) {
         this.pushToken(stringPartTag, start);
         const stringPartEnd = this.cursor.pos;
         this.cursor.pos += 1;
-        this.pushToken(ROC_TOKEN.StringEnd, stringPartEnd);
+        this.pushToken(T_STRING_END, stringPartEnd);
         return;
       } else {
         this.cursor.chompUTF8CodepointWithValidation();
         if (c === 92 && this.cursor.chompEscapeSequenceWithQuote(34) !== true) {
-          stringPartTag = ROC_TOKEN.MalformedStringPart;
+          stringPartTag = T_ERROR;
         }
       }
     }
@@ -1087,13 +1075,7 @@ function tokenizeRocSource(source) {
 }
 
 function classForRocToken(tag) {
-  if (ROC_MALFORMED_TOKENS.has(tag)) {
-    return "error";
-  }
-  if (tag.startsWith("Kw")) {
-    return "keyword";
-  }
-  return ROC_TOKEN_CLASSES.get(tag) ?? null;
+  return TOK_CLASS[tag & C_MASK];
 }
 
 function appendRocTokenHighlight(ranges, token) {
@@ -1102,13 +1084,10 @@ function appendRocTokenHighlight(ranges, token) {
     return;
   }
 
-  if (ROC_DOT_PREFIXED_TOKENS.has(token.tag) && token.start + 1 < token.end) {
+  if ((token.tag & F_DOT_PREFIX) !== 0 && token.start + 1 < token.end) {
     ranges.push({ start: token.start, end: token.start + 1, className: "punctuation" });
     ranges.push({ start: token.start + 1, end: token.end, className });
-  } else if (
-    (token.tag === ROC_TOKEN.OpDoubleDotLessThan || token.tag === ROC_TOKEN.OpDoubleDotEquals) &&
-    token.start + 2 < token.end
-  ) {
+  } else if ((token.tag & F_DOTDOT_PREFIX) !== 0 && token.start + 2 < token.end) {
     ranges.push({ start: token.start, end: token.start + 2, className: "punctuation" });
     ranges.push({ start: token.start + 2, end: token.end, className });
   } else {
@@ -1119,7 +1098,7 @@ function appendRocTokenHighlight(ranges, token) {
 function renderHighlightedRocSource(source) {
   const tokenized = tokenizeRocSource(source);
   const ranges = [...tokenized.comments];
-  const tokens = tokenized.tokens.filter((token) => token.tag !== ROC_TOKEN.EndOfFile && token.start !== token.end);
+  const tokens = tokenized.tokens.filter((token) => token.start !== token.end);
 
   for (let i = 0; i < tokens.length; i += 1) {
     const previous = tokens[i - 1];
@@ -1128,9 +1107,9 @@ function renderHighlightedRocSource(source) {
     if (
       previous != null &&
       next != null &&
-      ROC_RECORD_FIELD_PREFIXES.has(previous.tag) &&
-      ROC_RECORD_FIELD_NAMES.has(token.tag) &&
-      next.tag === ROC_TOKEN.OpColon &&
+      (previous.tag & F_FIELD_PREFIX) !== 0 &&
+      (token.tag & F_FIELD_NAME) !== 0 &&
+      (next.tag & F_COLON) !== 0 &&
       utf8Decode(tokenized.bytes.subarray(token.end, next.start)).trim() === ""
     ) {
       ranges.push({ start: token.start, end: next.end, className: "field" });

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -73,6 +73,1010 @@ function escapeHtml(text) {
     .replace(/>/g, "&gt;");
 }
 
+const ROC_TOKEN_NAMES = `
+  EndOfFile Float StringStart StringEnd MultilineStringStart StringPart MalformedStringPart
+  SingleQuote MalformedSingleQuote Int MalformedNumberBadSuffix MalformedNumberUnicodeSuffix
+  MalformedNumberNoDigits MalformedNumberNoExponentDigits MalformedInvalidUnicodeEscapeSequence
+  MalformedInvalidEscapeSequence UpperIdent LowerIdent MalformedUnicodeIdent Underscore
+  DotLowerIdent DotInt DotUpperIdent NoSpaceDotInt NoSpaceDotLowerIdent NoSpaceDotUpperIdent
+  MalformedDotUnicodeIdent MalformedNoSpaceDotUnicodeIdent NamedUnderscore
+  MalformedNamedUnderscoreUnicode OpaqueName MalformedOpaqueNameUnicode
+  MalformedOpaqueNameWithoutName OpenRound CloseRound OpenSquare CloseSquare OpenCurly
+  CloseCurly OpenStringInterpolation CloseStringInterpolation NoSpaceOpenRound OpPlus OpStar
+  OpPizza OpAssign OpBinaryMinus OpUnaryMinus OpNotEquals OpBang OpAnd OpAmpersand OpQuestion
+  OpDoubleQuestion OpOr OpBar OpDoubleSlash OpSlash OpPercent OpCaret OpGreaterThanOrEq
+  OpGreaterThan OpLessThanOrEq OpBackArrow OpLessThan OpDoubleDotLessThan OpDoubleDotEquals
+  OpEquals OpColonEqual OpDoubleColon NoSpaceOpQuestion Comma Dot DoubleDot TripleDot DotStar
+  OpColon OpArrow OpFatArrow OpBackslash KwApp KwAs KwCrash KwDbg KwElse KwExpect KwExposes
+  KwExposing KwFor KwGenerates KwHas KwHosted KwIf KwImplements KwImport KwImports KwIn
+  KwInterface KwMatch KwModule KwPackage KwPackages KwPlatform KwProvides KwRequires KwReturn
+  KwTargets KwVar KwWhere KwWhile KwWith KwBreak MalformedUnknownToken
+`.trim().split(/\s+/);
+
+const ROC_TOKEN = Object.freeze(Object.fromEntries(ROC_TOKEN_NAMES.map((name) => [name, name])));
+
+function rocTokenSet(names) {
+  return new Set(names.trim().split(/\s+/).map((name) => ROC_TOKEN[name]));
+}
+
+function tokenClass(className, names) {
+  return names.trim().split(/\s+/).map((name) => [ROC_TOKEN[name], className]);
+}
+
+const ROC_KEYWORDS = new Map([
+  ["and", ROC_TOKEN.OpAnd],
+  ["or", ROC_TOKEN.OpOr],
+  ..."app as crash dbg else expect exposes exposing for generates has hosted if implements import imports in interface match module package packages platform provides requires return targets var where while with break"
+    .split(/\s+/)
+    .map((word) => [word, ROC_TOKEN[`Kw${word[0].toUpperCase()}${word.slice(1)}`]]),
+]);
+
+const ROC_NUMBER_SUFFIXES = new Set("dec f32 f64 i128 i16 i32 i64 i8 nat u128 u16 u32 u64 u8".split(" "));
+
+const ROC_MALFORMED_TOKENS = rocTokenSet(`
+  MalformedDotUnicodeIdent MalformedInvalidEscapeSequence MalformedInvalidUnicodeEscapeSequence
+  MalformedNamedUnderscoreUnicode MalformedNoSpaceDotUnicodeIdent MalformedNumberBadSuffix
+  MalformedNumberNoDigits MalformedNumberNoExponentDigits MalformedNumberUnicodeSuffix
+  MalformedOpaqueNameUnicode MalformedOpaqueNameWithoutName MalformedUnicodeIdent
+  MalformedUnknownToken MalformedSingleQuote MalformedStringPart
+`);
+
+const ROC_EXPR_END_TOKENS = rocTokenSet(`
+  LowerIdent UpperIdent MalformedUnicodeIdent NamedUnderscore MalformedNamedUnderscoreUnicode
+  OpaqueName MalformedOpaqueNameUnicode DotLowerIdent DotUpperIdent DotInt NoSpaceDotLowerIdent
+  NoSpaceDotUpperIdent NoSpaceDotInt MalformedDotUnicodeIdent MalformedNoSpaceDotUnicodeIdent
+  Int Float MalformedNumberBadSuffix MalformedNumberUnicodeSuffix MalformedNumberNoDigits
+  MalformedNumberNoExponentDigits CloseRound CloseSquare CloseCurly CloseStringInterpolation
+  StringEnd SingleQuote MalformedSingleQuote
+`);
+
+const ROC_RECORD_FIELD_PREFIXES = rocTokenSet("OpenCurly Comma OpAmpersand OpBackArrow");
+const ROC_RECORD_FIELD_NAMES = rocTokenSet("LowerIdent NamedUnderscore");
+const ROC_DOT_PREFIXED_TOKENS = rocTokenSet(`
+  DotLowerIdent DotUpperIdent DotInt NoSpaceDotLowerIdent NoSpaceDotUpperIdent NoSpaceDotInt
+  MalformedDotUnicodeIdent MalformedNoSpaceDotUnicodeIdent DotStar
+`);
+
+const ROC_TOKEN_CLASSES = new Map([
+  ...tokenClass("upperident", "UpperIdent DotUpperIdent NoSpaceDotUpperIdent OpaqueName"),
+  ...tokenClass("lowerident", "LowerIdent DotLowerIdent NoSpaceDotLowerIdent NamedUnderscore"),
+  ...tokenClass("literal", "Int Float DotInt NoSpaceDotInt"),
+  ...tokenClass("string", "StringStart StringEnd MultilineStringStart StringPart SingleQuote"),
+  ...tokenClass("keyword", "OpenStringInterpolation CloseStringInterpolation"),
+  ...tokenClass("punctuation", "NoSpaceOpenRound OpenRound CloseRound OpenCurly CloseCurly Comma Dot DoubleDot TripleDot"),
+  ...tokenClass("delimiter", "OpenSquare CloseSquare"),
+  ...tokenClass("op",
+    `OpPlus OpStar OpPizza OpAssign OpBinaryMinus OpUnaryMinus OpNotEquals OpBang OpAnd OpAmpersand
+    OpQuestion OpDoubleQuestion OpOr OpBar OpDoubleSlash OpSlash OpPercent OpCaret OpGreaterThanOrEq
+    OpGreaterThan OpLessThanOrEq OpBackArrow OpLessThan OpDoubleDotLessThan OpDoubleDotEquals
+    OpEquals OpColonEqual OpDoubleColon NoSpaceOpQuestion DotStar OpColon OpArrow OpFatArrow OpBackslash`,
+  ),
+]);
+
+function updateIfNotMalformed(tok, next) {
+  return ROC_MALFORMED_TOKENS.has(tok) ? tok : next;
+}
+
+function isAsciiLower(c) {
+  return c >= 97 && c <= 122;
+}
+
+function isAsciiUpper(c) {
+  return c >= 65 && c <= 90;
+}
+
+function isAsciiDigit(c) {
+  return c >= 48 && c <= 57;
+}
+
+function isHexDigit(c) {
+  return isAsciiDigit(c) || (c >= 97 && c <= 102) || (c >= 65 && c <= 70);
+}
+
+function canFollowUnaryMinus(c) {
+  return isAsciiLower(c) || isAsciiUpper(c) || c === 95 || c === 40 || c >= 0x80;
+}
+
+function utf8SequenceLength(c) {
+  if (c < 0x80) return 1;
+  if (c >= 0xc2 && c <= 0xdf) return 2;
+  if (c >= 0xe0 && c <= 0xef) return 3;
+  if (c >= 0xf0 && c <= 0xf4) return 4;
+  return null;
+}
+
+function isValidUnicodeCodepoint(codepoint) {
+  return codepoint <= 0x10ffff && !(codepoint >= 0xd800 && codepoint <= 0xdfff);
+}
+
+class RocCursor {
+  constructor(text) {
+    this.buf = utf8Encode(text);
+    this.pos = 0;
+    this.commentRanges = [];
+  }
+
+  peek() {
+    return this.pos < this.buf.length ? this.buf[this.pos] : null;
+  }
+
+  peekAt(lookahead) {
+    const idx = this.pos + lookahead;
+    return idx < this.buf.length ? this.buf[idx] : null;
+  }
+
+  isPeekedCharInRange(lookahead, start, end) {
+    const peeked = this.peekAt(lookahead);
+    return peeked != null && peeked >= start && peeked <= end;
+  }
+
+  chompTrivia() {
+    while (this.pos < this.buf.length) {
+      const b = this.buf[this.pos];
+      if (b === 32 || b === 9 || b === 10) {
+        this.pos += 1;
+      } else if (b === 13) {
+        this.pos += 1;
+        if (this.pos < this.buf.length && this.buf[this.pos] === 10) {
+          this.pos += 1;
+        }
+      } else if (b === 35) {
+        const start = this.pos;
+        this.pos += 1;
+        while (
+          this.pos < this.buf.length &&
+          this.buf[this.pos] !== 10 &&
+          this.buf[this.pos] !== 13
+        ) {
+          this.pos += 1;
+        }
+        this.commentRanges.push({ start, end: this.pos, className: "comment" });
+      } else if (b >= 0 && b <= 31) {
+        this.pos += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  chompNumber() {
+    const initialDigit = this.buf[this.pos];
+    this.pos += 1;
+
+    let tok = ROC_TOKEN.Int;
+    if (initialDigit === 48) {
+      while (true) {
+        const c = this.peek() ?? 0;
+        if (c === 120 || c === 88) {
+          this.pos += 1;
+          if (!this.chompIntegerBase16()) {
+            tok = ROC_TOKEN.MalformedNumberNoDigits;
+          }
+          tok = this.chompNumberSuffix(tok);
+          break;
+        } else if (c === 111 || c === 79) {
+          this.pos += 1;
+          if (!this.chompIntegerBase8()) {
+            tok = ROC_TOKEN.MalformedNumberNoDigits;
+          }
+          tok = this.chompNumberSuffix(tok);
+          break;
+        } else if (c === 98 || c === 66) {
+          this.pos += 1;
+          if (!this.chompIntegerBase2()) {
+            tok = ROC_TOKEN.MalformedNumberNoDigits;
+          }
+          tok = this.chompNumberSuffix(tok);
+          break;
+        } else if (isAsciiDigit(c)) {
+          tok = this.chompNumberBase10();
+          tok = this.chompNumberSuffix(tok);
+          break;
+        } else if (c === 95) {
+          this.pos += 1;
+        } else if (c === 46) {
+          this.pos -= 1;
+          tok = this.chompNumberBase10();
+          tok = this.chompNumberSuffix(tok);
+          break;
+        } else {
+          tok = this.chompNumberSuffix(tok);
+          break;
+        }
+      }
+    } else {
+      tok = this.chompNumberBase10();
+      tok = this.chompNumberSuffix(tok);
+    }
+    return tok;
+  }
+
+  chompExponent() {
+    const c = this.peek() ?? 0;
+    if (c === 101 || c === 69) {
+      this.pos += 1;
+      const sign = this.peek() ?? 0;
+      if (sign === 43 || sign === 45) {
+        this.pos += 1;
+      }
+      if (!this.chompIntegerBase10()) {
+        return "EmptyExponent";
+      }
+      return true;
+    }
+    return false;
+  }
+
+  chompNumberSuffix(hypothesis) {
+    const c = this.peek();
+    if (c == null) {
+      return hypothesis;
+    }
+    const isIdentChar =
+      isAsciiLower(c) ||
+      isAsciiUpper(c) ||
+      isAsciiDigit(c) ||
+      c === 95 ||
+      c === 36 ||
+      c >= 0x80;
+    if (!isIdentChar) {
+      return hypothesis;
+    }
+
+    const start = this.pos;
+    if (!this.chompIdentGeneral()) {
+      return updateIfNotMalformed(hypothesis, ROC_TOKEN.MalformedNumberUnicodeSuffix);
+    }
+    const suffix = utf8Decode(this.buf.subarray(start, this.pos));
+    if (!ROC_NUMBER_SUFFIXES.has(suffix)) {
+      return updateIfNotMalformed(hypothesis, ROC_TOKEN.MalformedNumberBadSuffix);
+    }
+    return hypothesis;
+  }
+
+  chompNumberBase10() {
+    let tokenType = ROC_TOKEN.Int;
+    this.chompIntegerBase10();
+    if (
+      (this.peek() ?? 0) === 46 &&
+      (this.isPeekedCharInRange(1, 48, 57) ||
+        this.peekAt(1) === 101 ||
+        this.peekAt(1) === 69)
+    ) {
+      this.pos += 1;
+      this.chompIntegerBase10();
+      tokenType = ROC_TOKEN.Float;
+    }
+
+    const hasExponent = this.chompExponent();
+    if (hasExponent === "EmptyExponent") {
+      return ROC_TOKEN.MalformedNumberNoExponentDigits;
+    }
+    if (hasExponent) {
+      tokenType = ROC_TOKEN.Float;
+    }
+    return tokenType;
+  }
+
+  chompIntegerBase10() {
+    let containsDigits = false;
+    while (this.peek() != null) {
+      const c = this.peek();
+      if (isAsciiDigit(c)) {
+        containsDigits = true;
+        this.pos += 1;
+      } else if (c === 95) {
+        this.pos += 1;
+      } else {
+        break;
+      }
+    }
+    return containsDigits;
+  }
+
+  chompIntegerBase16() {
+    let containsDigits = false;
+    while (this.peek() != null) {
+      const c = this.peek();
+      if (isHexDigit(c)) {
+        containsDigits = true;
+        this.pos += 1;
+      } else if (c === 95) {
+        this.pos += 1;
+      } else {
+        break;
+      }
+    }
+    return containsDigits;
+  }
+
+  chompIntegerBase8() {
+    let containsDigits = false;
+    while (this.peek() != null) {
+      const c = this.peek();
+      if (c >= 48 && c <= 55) {
+        containsDigits = true;
+        this.pos += 1;
+      } else if (c === 95) {
+        this.pos += 1;
+      } else {
+        break;
+      }
+    }
+    return containsDigits;
+  }
+
+  chompIntegerBase2() {
+    let containsDigits = false;
+    while (this.peek() != null) {
+      const c = this.peek();
+      if (c === 48 || c === 49) {
+        containsDigits = true;
+        this.pos += 1;
+      } else if (c === 95) {
+        this.pos += 1;
+      } else {
+        break;
+      }
+    }
+    return containsDigits;
+  }
+
+  chompIdentLower() {
+    const start = this.pos;
+    if (!this.chompIdentGeneral()) {
+      return ROC_TOKEN.MalformedUnicodeIdent;
+    }
+    const ident = utf8Decode(this.buf.subarray(start, this.pos));
+    return ROC_KEYWORDS.get(ident) ?? ROC_TOKEN.LowerIdent;
+  }
+
+  chompIdentGeneral() {
+    let valid = true;
+    while (this.pos < this.buf.length) {
+      const c = this.buf[this.pos];
+      if (
+        isAsciiLower(c) ||
+        isAsciiUpper(c) ||
+        isAsciiDigit(c) ||
+        c === 95 ||
+        c === 33 ||
+        c === 36
+      ) {
+        this.pos += 1;
+      } else if (c >= 0x80) {
+        valid = false;
+        this.pos += 1;
+      } else {
+        break;
+      }
+    }
+    return valid;
+  }
+
+  chompInteger() {
+    while (this.pos < this.buf.length && isAsciiDigit(this.buf[this.pos])) {
+      this.pos += 1;
+    }
+  }
+
+  chompEscapeSequenceWithQuote(quoteChar) {
+    const c = this.peek() ?? 0;
+
+    if (c === 92 || c === 34 || c === 39 || c === 110 || c === 114 || c === 116 || c === 36) {
+      this.pos += 1;
+      return true;
+    }
+
+    if (c === 117) {
+      this.pos += 1;
+      if (this.peek() === 40) {
+        this.pos += 1;
+      } else {
+        return "InvalidUnicodeEscapeSequence";
+      }
+
+      const hexStart = this.pos;
+      while (true) {
+        if (this.peek() === 41) {
+          if (this.pos === hexStart) {
+            this.pos += 1;
+            return "InvalidUnicodeEscapeSequence";
+          }
+          this.pos += 1;
+          break;
+        } else if (this.peek() != null) {
+          const next = this.peek();
+          if (isHexDigit(next)) {
+            this.pos += 1;
+          } else {
+            while (this.pos < this.buf.length) {
+              const nextChar = this.peek() ?? 0;
+              if (nextChar === 41 || nextChar === 10) {
+                break;
+              }
+              if (quoteChar != null && nextChar === quoteChar) {
+                break;
+              }
+              this.pos += 1;
+            }
+            if (this.pos < this.buf.length && this.peek() === 41) {
+              this.pos += 1;
+            }
+            return "InvalidUnicodeEscapeSequence";
+          }
+        } else {
+          return "InvalidUnicodeEscapeSequence";
+        }
+      }
+
+      const hexCode = utf8Decode(this.buf.subarray(hexStart, this.pos - 1));
+      const codepoint = Number.parseInt(hexCode, 16);
+      if (!Number.isFinite(codepoint) || !isValidUnicodeCodepoint(codepoint)) {
+        return "InvalidUnicodeEscapeSequence";
+      }
+
+      return true;
+    }
+
+    return "InvalidEscapeSequence";
+  }
+
+  chompSingleQuoteLiteral() {
+    this.pos += 1;
+    let state = "Empty";
+
+    while (this.pos < this.buf.length) {
+      const c = this.buf[this.pos];
+      if (c === 10) {
+        break;
+      }
+
+      this.pos += 1;
+
+      if (state === "Empty") {
+        if (c === 39) {
+          return ROC_TOKEN.MalformedSingleQuote;
+        }
+        if (c === 92) {
+          state = "Enough";
+          if (this.chompEscapeSequenceWithQuote(39) !== true) {
+            state = "Invalid";
+          }
+        } else {
+          this.pos -= 1;
+          this.chompUTF8CodepointWithValidation();
+          state = "Enough";
+        }
+      } else if (state === "Enough") {
+        if (c === 39) {
+          return ROC_TOKEN.SingleQuote;
+        }
+        state = "TooLong";
+      } else if (state === "TooLong") {
+        if (c === 39) {
+          return ROC_TOKEN.MalformedSingleQuote;
+        }
+      } else if (state === "Invalid" && c === 39) {
+        return ROC_TOKEN.MalformedSingleQuote;
+      }
+    }
+
+    return ROC_TOKEN.MalformedSingleQuote;
+  }
+
+  chompUTF8CodepointWithValidation() {
+    const c = this.buf[this.pos];
+
+    if (c < 0x80) {
+      this.pos += 1;
+      return c;
+    }
+
+    const utf8Len = utf8SequenceLength(c);
+    if (utf8Len == null || this.pos + utf8Len > this.buf.length) {
+      this.pos += 1;
+      return null;
+    }
+
+    let codepoint;
+    if (utf8Len === 2) {
+      codepoint = ((c & 0x1f) << 6) | (this.buf[this.pos + 1] & 0x3f);
+    } else if (utf8Len === 3) {
+      codepoint =
+        ((c & 0x0f) << 12) |
+        ((this.buf[this.pos + 1] & 0x3f) << 6) |
+        (this.buf[this.pos + 2] & 0x3f);
+    } else {
+      codepoint =
+        ((c & 0x07) << 18) |
+        ((this.buf[this.pos + 1] & 0x3f) << 12) |
+        ((this.buf[this.pos + 2] & 0x3f) << 6) |
+        (this.buf[this.pos + 3] & 0x3f);
+    }
+
+    this.pos += utf8Len;
+    return codepoint;
+  }
+}
+
+class RocTokenizer {
+  constructor(text) {
+    this.cursor = new RocCursor(text);
+    this.tokens = [];
+    this.stringInterpolationStack = [];
+  }
+
+  lastTokenTag() {
+    return this.tokens.length === 0 ? null : this.tokens[this.tokens.length - 1].tag;
+  }
+
+  pushToken(tag, start) {
+    this.tokens.push({ tag, start, end: this.cursor.pos });
+  }
+
+  tokenize() {
+    let sawWhitespace = true;
+
+    while (this.cursor.pos < this.cursor.buf.length) {
+      const start = this.cursor.pos;
+      const sp = sawWhitespace;
+      sawWhitespace = false;
+      const b = this.cursor.buf[this.cursor.pos];
+
+      if (b <= 32 || b === 35) {
+        this.cursor.chompTrivia();
+        sawWhitespace = true;
+      } else if (b === 46) {
+        this.tokenizeDot(start, sp);
+      } else if (b === 45) {
+        this.tokenizeMinus(start, sp);
+      } else if (b === 33) {
+        if (this.cursor.peekAt(1) === 61) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpNotEquals, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpBang, start);
+        }
+      } else if (b === 38) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpAmpersand, start);
+      } else if (b === 44) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.Comma, start);
+      } else if (b === 63) {
+        if (this.cursor.peekAt(1) === 63) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpDoubleQuestion, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(sp ? ROC_TOKEN.OpQuestion : ROC_TOKEN.NoSpaceOpQuestion, start);
+        }
+      } else if (b === 124) {
+        if (this.cursor.peekAt(1) === 62) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpPizza, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpBar, start);
+        }
+      } else if (b === 43) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpPlus, start);
+      } else if (b === 42) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpStar, start);
+      } else if (b === 47) {
+        if (this.cursor.peekAt(1) === 47) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpDoubleSlash, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpSlash, start);
+        }
+      } else if (b === 92) {
+        if (this.cursor.peekAt(1) === 92) {
+          this.tokenizeMultilineStringLiteral();
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpBackslash, start);
+        }
+      } else if (b === 37) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpPercent, start);
+      } else if (b === 94) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpCaret, start);
+      } else if (b === 62) {
+        if (this.cursor.peekAt(1) === 61) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpGreaterThanOrEq, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpGreaterThan, start);
+        }
+      } else if (b === 60) {
+        if (this.cursor.peekAt(1) === 61) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpLessThanOrEq, start);
+        } else if (this.cursor.peekAt(1) === 45) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpBackArrow, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpLessThan, start);
+        }
+      } else if (b === 61) {
+        if (this.cursor.peekAt(1) === 61) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpEquals, start);
+        } else if (this.cursor.peekAt(1) === 62) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpFatArrow, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpAssign, start);
+        }
+      } else if (b === 58) {
+        if (this.cursor.peekAt(1) === 61) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpColonEqual, start);
+        } else if (this.cursor.peekAt(1) === 58) {
+          this.cursor.pos += 2;
+          this.pushToken(ROC_TOKEN.OpDoubleColon, start);
+        } else {
+          this.cursor.pos += 1;
+          this.pushToken(ROC_TOKEN.OpColon, start);
+        }
+      } else if (b === 40) {
+        this.cursor.pos += 1;
+        this.pushToken(sp ? ROC_TOKEN.OpenRound : ROC_TOKEN.NoSpaceOpenRound, start);
+      } else if (b === 91) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpenSquare, start);
+      } else if (b === 123) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpenCurly, start);
+      } else if (b === 41) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.CloseRound, start);
+      } else if (b === 93) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.CloseSquare, start);
+      } else if (b === 125) {
+        this.cursor.pos += 1;
+        if (this.stringInterpolationStack.length > 0) {
+          const last = this.stringInterpolationStack.pop();
+          this.pushToken(ROC_TOKEN.CloseStringInterpolation, start);
+          this.tokenizeStringLikeLiteralBody(last);
+        } else {
+          this.pushToken(ROC_TOKEN.CloseCurly, start);
+        }
+      } else if (b === 95) {
+        this.tokenizeUnderscore(start);
+      } else if (b === 64) {
+        this.tokenizeOpaqueName(start);
+      } else if (b === 36) {
+        this.tokenizeDollar(start);
+      } else if (isAsciiDigit(b)) {
+        const tag = this.cursor.chompNumber();
+        this.pushToken(tag, start);
+      } else if (isAsciiLower(b)) {
+        const tag = this.cursor.chompIdentLower();
+        this.pushToken(tag, start);
+      } else if (isAsciiUpper(b)) {
+        let tag = ROC_TOKEN.UpperIdent;
+        if (!this.cursor.chompIdentGeneral()) {
+          tag = ROC_TOKEN.MalformedUnicodeIdent;
+        }
+        this.pushToken(tag, start);
+      } else if (b === 39) {
+        const tag = this.cursor.chompSingleQuoteLiteral();
+        this.pushToken(tag, start);
+      } else if (b === 34) {
+        this.tokenizeStringLikeLiteral();
+      } else if (b >= 0x80) {
+        this.cursor.chompIdentGeneral();
+        this.pushToken(ROC_TOKEN.MalformedUnicodeIdent, start);
+      } else {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.MalformedUnknownToken, start);
+      }
+    }
+
+    this.pushToken(ROC_TOKEN.EndOfFile, this.cursor.pos);
+    return {
+      tokens: this.tokens,
+      comments: this.cursor.commentRanges,
+      bytes: this.cursor.buf,
+    };
+  }
+
+  tokenizeDot(start, sp) {
+    const next = this.cursor.peekAt(1);
+    if (next == null) {
+      this.cursor.pos += 1;
+      this.pushToken(ROC_TOKEN.Dot, start);
+    } else if (next === 46) {
+      if (this.cursor.peekAt(2) === 46) {
+        this.cursor.pos += 3;
+        this.pushToken(ROC_TOKEN.TripleDot, start);
+      } else if (this.cursor.peekAt(2) === 60) {
+        this.cursor.pos += 3;
+        this.pushToken(ROC_TOKEN.OpDoubleDotLessThan, start);
+      } else if (this.cursor.peekAt(2) === 61) {
+        this.cursor.pos += 3;
+        this.pushToken(ROC_TOKEN.OpDoubleDotEquals, start);
+      } else {
+        this.cursor.pos += 2;
+        this.pushToken(ROC_TOKEN.DoubleDot, start);
+      }
+    } else if (isAsciiDigit(next)) {
+      this.cursor.pos += 1;
+      this.cursor.chompInteger();
+      this.pushToken(sp ? ROC_TOKEN.DotInt : ROC_TOKEN.NoSpaceDotInt, start);
+    } else if (isAsciiLower(next)) {
+      let tag = sp ? ROC_TOKEN.DotLowerIdent : ROC_TOKEN.NoSpaceDotLowerIdent;
+      this.cursor.pos += 1;
+      if (!this.cursor.chompIdentGeneral()) {
+        tag = ROC_TOKEN.MalformedDotUnicodeIdent;
+      }
+      this.pushToken(tag, start);
+    } else if (isAsciiUpper(next)) {
+      let tag = sp ? ROC_TOKEN.DotUpperIdent : ROC_TOKEN.NoSpaceDotUpperIdent;
+      this.cursor.pos += 1;
+      if (!this.cursor.chompIdentGeneral()) {
+        tag = ROC_TOKEN.MalformedDotUnicodeIdent;
+      }
+      this.pushToken(tag, start);
+    } else if (next >= 0x80 && next <= 0xff) {
+      this.cursor.pos += 1;
+      this.cursor.chompIdentGeneral();
+      this.pushToken(ROC_TOKEN.MalformedDotUnicodeIdent, start);
+    } else if (next === 123) {
+      this.cursor.pos += 1;
+      this.pushToken(ROC_TOKEN.Dot, start);
+    } else if (next === 42) {
+      this.cursor.pos += 2;
+      this.pushToken(ROC_TOKEN.DotStar, start);
+    } else {
+      this.cursor.pos += 1;
+      this.pushToken(ROC_TOKEN.Dot, start);
+    }
+  }
+
+  tokenizeMinus(start, sp) {
+    const next = this.cursor.peekAt(1);
+    if (next == null) {
+      this.cursor.pos += 1;
+      this.pushToken(ROC_TOKEN.OpUnaryMinus, start);
+    } else if (next === 62) {
+      this.cursor.pos += 2;
+      this.pushToken(ROC_TOKEN.OpArrow, start);
+    } else if (next === 32 || next === 9 || next === 10 || next === 13 || next === 35) {
+      this.cursor.pos += 1;
+      this.pushToken(ROC_TOKEN.OpBinaryMinus, start);
+    } else if (isAsciiDigit(next)) {
+      const prev = this.lastTokenTag();
+      if (!sp && prev != null && ROC_EXPR_END_TOKENS.has(prev)) {
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.OpBinaryMinus, start);
+      } else {
+        this.cursor.pos += 1;
+        const tag = this.cursor.chompNumber();
+        this.pushToken(tag, start);
+      }
+    } else {
+      this.cursor.pos += 1;
+      this.pushToken(canFollowUnaryMinus(next) ? ROC_TOKEN.OpUnaryMinus : ROC_TOKEN.OpBinaryMinus, start);
+    }
+  }
+
+  tokenizeUnderscore(start) {
+    const next = this.cursor.peekAt(1);
+    if (next != null && (isAsciiLower(next) || isAsciiUpper(next) || isAsciiDigit(next))) {
+      let tag = ROC_TOKEN.NamedUnderscore;
+      this.cursor.pos += 2;
+      if (!this.cursor.chompIdentGeneral()) {
+        tag = ROC_TOKEN.MalformedNamedUnderscoreUnicode;
+      }
+      this.pushToken(tag, start);
+    } else {
+      this.cursor.pos += 1;
+      this.pushToken(ROC_TOKEN.Underscore, start);
+    }
+  }
+
+  tokenizeOpaqueName(start) {
+    let tok = ROC_TOKEN.OpaqueName;
+    const next = this.cursor.peekAt(1);
+    if (
+      next != null &&
+      (isAsciiLower(next) || isAsciiUpper(next) || isAsciiDigit(next) || next === 95 || next >= 0x80)
+    ) {
+      this.cursor.pos += 1;
+      if (!this.cursor.chompIdentGeneral()) {
+        tok = ROC_TOKEN.MalformedOpaqueNameUnicode;
+      }
+    } else {
+      tok = ROC_TOKEN.MalformedOpaqueNameWithoutName;
+      this.cursor.pos += 1;
+    }
+    this.pushToken(tok, start);
+  }
+
+  tokenizeDollar(start) {
+    const next = this.cursor.peekAt(1);
+    if (next != null && isAsciiLower(next)) {
+      let tag = ROC_TOKEN.LowerIdent;
+      this.cursor.pos += 1;
+      if (!this.cursor.chompIdentGeneral()) {
+        tag = ROC_TOKEN.MalformedUnicodeIdent;
+      }
+      this.pushToken(tag, start);
+    } else if (next != null && isAsciiUpper(next)) {
+      let tag = ROC_TOKEN.UpperIdent;
+      this.cursor.pos += 1;
+      if (!this.cursor.chompIdentGeneral()) {
+        tag = ROC_TOKEN.MalformedUnicodeIdent;
+      }
+      this.pushToken(tag, start);
+    } else {
+      this.cursor.pos += 1;
+      this.pushToken(ROC_TOKEN.MalformedUnknownToken, start);
+    }
+  }
+
+  tokenizeStringLikeLiteral() {
+    const start = this.cursor.pos;
+    this.cursor.pos += 1;
+    let kind = "single_line";
+    if (this.cursor.peek() === 34 && this.cursor.peekAt(1) === 34) {
+      this.cursor.pos += 2;
+      kind = "multi_line";
+      this.pushToken(ROC_TOKEN.MultilineStringStart, start);
+    } else {
+      this.pushToken(ROC_TOKEN.StringStart, start);
+    }
+    this.tokenizeStringLikeLiteralBody(kind);
+  }
+
+  tokenizeMultilineStringLiteral() {
+    const start = this.cursor.pos;
+    this.cursor.pos += 2;
+    this.pushToken(ROC_TOKEN.MultilineStringStart, start);
+    this.tokenizeStringLikeLiteralBody("multi_line");
+  }
+
+  tokenizeStringLikeLiteralBody(kind) {
+    const start = this.cursor.pos;
+    let stringPartTag = ROC_TOKEN.StringPart;
+    while (this.cursor.pos < this.cursor.buf.length) {
+      const c = this.cursor.buf[this.cursor.pos];
+      if (c === 36 && this.cursor.peekAt(1) === 123) {
+        this.pushToken(stringPartTag, start);
+        const dollarStart = this.cursor.pos;
+        this.cursor.pos += 2;
+        this.pushToken(ROC_TOKEN.OpenStringInterpolation, dollarStart);
+        this.stringInterpolationStack.push(kind);
+        return;
+      } else if (c === 10) {
+        this.pushToken(stringPartTag, start);
+        if (kind === "single_line") {
+          this.pushToken(ROC_TOKEN.StringEnd, this.cursor.pos);
+        }
+        return;
+      } else if (kind === "single_line" && c === 34) {
+        this.pushToken(stringPartTag, start);
+        const stringPartEnd = this.cursor.pos;
+        this.cursor.pos += 1;
+        this.pushToken(ROC_TOKEN.StringEnd, stringPartEnd);
+        return;
+      } else {
+        this.cursor.chompUTF8CodepointWithValidation();
+        if (c === 92 && this.cursor.chompEscapeSequenceWithQuote(34) !== true) {
+          stringPartTag = ROC_TOKEN.MalformedStringPart;
+        }
+      }
+    }
+    this.pushToken(stringPartTag, start);
+  }
+}
+
+function tokenizeRocSource(source) {
+  return new RocTokenizer(source).tokenize();
+}
+
+function classForRocToken(tag) {
+  if (ROC_MALFORMED_TOKENS.has(tag)) {
+    return "error";
+  }
+  if (tag.startsWith("Kw")) {
+    return "keyword";
+  }
+  return ROC_TOKEN_CLASSES.get(tag) ?? null;
+}
+
+function appendRocTokenHighlight(ranges, token) {
+  const className = classForRocToken(token.tag);
+  if (className == null) {
+    return;
+  }
+
+  if (ROC_DOT_PREFIXED_TOKENS.has(token.tag) && token.start + 1 < token.end) {
+    ranges.push({ start: token.start, end: token.start + 1, className: "punctuation" });
+    ranges.push({ start: token.start + 1, end: token.end, className });
+  } else if (
+    (token.tag === ROC_TOKEN.OpDoubleDotLessThan || token.tag === ROC_TOKEN.OpDoubleDotEquals) &&
+    token.start + 2 < token.end
+  ) {
+    ranges.push({ start: token.start, end: token.start + 2, className: "punctuation" });
+    ranges.push({ start: token.start + 2, end: token.end, className });
+  } else {
+    ranges.push({ start: token.start, end: token.end, className });
+  }
+}
+
+function renderHighlightedRocSource(source) {
+  const tokenized = tokenizeRocSource(source);
+  const ranges = [...tokenized.comments];
+  const tokens = tokenized.tokens.filter((token) => token.tag !== ROC_TOKEN.EndOfFile && token.start !== token.end);
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const previous = tokens[i - 1];
+    const token = tokens[i];
+    const next = tokens[i + 1];
+    if (
+      previous != null &&
+      next != null &&
+      ROC_RECORD_FIELD_PREFIXES.has(previous.tag) &&
+      ROC_RECORD_FIELD_NAMES.has(token.tag) &&
+      next.tag === ROC_TOKEN.OpColon &&
+      utf8Decode(tokenized.bytes.subarray(token.end, next.start)).trim() === ""
+    ) {
+      ranges.push({ start: token.start, end: next.end, className: "field" });
+      i += 1;
+    } else {
+      appendRocTokenHighlight(ranges, token);
+    }
+  }
+
+  ranges.sort((a, b) => a.start - b.start || a.end - b.end);
+
+  let html = "";
+  let lastEnd = 0;
+  for (const range of ranges) {
+    if (range.start < lastEnd) {
+      continue;
+    }
+    html += escapeHtml(utf8Decode(tokenized.bytes.subarray(lastEnd, range.start)));
+    html += `<span class="${range.className}">`;
+    html += escapeHtml(utf8Decode(tokenized.bytes.subarray(range.start, range.end)));
+    html += "</span>";
+    lastEnd = range.end;
+  }
+  html += escapeHtml(utf8Decode(tokenized.bytes.subarray(lastEnd)));
+  return html || " ";
+}
+
+function setupHighlightedSource(textarea, highlight) {
+  const updateHighlight = () => {
+    highlight.innerHTML = renderHighlightedRocSource(textarea.value);
+  };
+
+  const syncScroll = () => {
+    highlight.scrollTop = textarea.scrollTop;
+    highlight.scrollLeft = textarea.scrollLeft;
+  };
+
+  textarea.addEventListener("input", updateHighlight);
+  textarea.addEventListener("scroll", syncScroll);
+
+  updateHighlight();
+  syncScroll();
+}
+
 function setupExample(div) {
   // The Run button is added statically in the markup (so it shows even before
   // this script loads). Pull it out before reading the source so its label
@@ -90,6 +1094,14 @@ function setupExample(div) {
   textarea.wrap = "off";
   textarea.className = "roc-source";
 
+  const sourceEditor = document.createElement("div");
+  sourceEditor.className = "roc-source-editor";
+
+  const sourceHighlight = document.createElement("pre");
+  sourceHighlight.className = "roc-source-highlight";
+  sourceHighlight.setAttribute("aria-hidden", "true");
+  setupHighlightedSource(textarea, sourceHighlight);
+
   // Keep Tab from leaving the textarea
   textarea.addEventListener("keydown", (e) => {
     if (e.key === "Tab") {
@@ -98,6 +1110,7 @@ function setupExample(div) {
       const s = ta.selectionStart;
       ta.value = ta.value.slice(0, s) + "\t" + ta.value.slice(ta.selectionEnd);
       ta.selectionStart = ta.selectionEnd = s + 1;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
     }
   });
 
@@ -164,7 +1177,9 @@ function setupExample(div) {
     runButton.disabled = false;
   });
 
-  div.appendChild(textarea);
+  sourceEditor.appendChild(sourceHighlight);
+  sourceEditor.appendChild(textarea);
+  div.appendChild(sourceEditor);
   div.appendChild(runButton);
   div.appendChild(outputArea);
 }

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -73,6 +73,104 @@ function escapeHtml(text) {
     .replace(/>/g, "&gt;");
 }
 
+const ANSI_COLOR_CLASSES = [
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+];
+
+function renderAnsiTerminal(text) {
+  const state = { bold: false, dim: false, italic: false, underline: false, fg: null };
+
+  const classes = () => {
+    const result = [];
+    if (state.bold) result.push("ansi-bold");
+    if (state.dim) result.push("ansi-dim");
+    if (state.italic) result.push("ansi-italic");
+    if (state.underline) result.push("ansi-underline");
+    if (state.fg) result.push(`ansi-fg-${state.fg}`);
+    return result.join(" ");
+  };
+
+  const span = (chunk) => {
+    if (!chunk) return "";
+    const cls = classes();
+    const escaped = escapeHtml(chunk);
+    return cls ? `<span class="${cls}">${escaped}</span>` : escaped;
+  };
+
+  const applySgr = (body) => {
+    const params = body === "" ? [0] : body.split(";").map(Number);
+    for (const code of params) {
+      if (!Number.isInteger(code)) continue;
+
+      if (code === 0) {
+        state.bold = false;
+        state.dim = false;
+        state.italic = false;
+        state.underline = false;
+        state.fg = null;
+      } else if (code === 1) {
+        state.bold = true;
+      } else if (code === 2) {
+        state.dim = true;
+      } else if (code === 3) {
+        state.italic = true;
+      } else if (code === 4) {
+        state.underline = true;
+      } else if (code === 22) {
+        state.bold = false;
+        state.dim = false;
+      } else if (code === 23) {
+        state.italic = false;
+      } else if (code === 24) {
+        state.underline = false;
+      } else if (code === 39) {
+        state.fg = null;
+      } else if (code >= 30 && code <= 37) {
+        state.fg = ANSI_COLOR_CLASSES[code - 30];
+      } else if (code >= 90 && code <= 97) {
+        state.fg = `bright-${ANSI_COLOR_CLASSES[code - 90]}`;
+      }
+    }
+  };
+
+  let html = "";
+  let index = 0;
+  while (index < text.length) {
+    const esc = text.indexOf("\x1b[", index);
+    if (esc === -1) {
+      html += span(text.slice(index));
+      break;
+    }
+
+    html += span(text.slice(index, esc));
+    const end = text.indexOf("m", esc + 2);
+    if (end === -1) {
+      html += escapeHtml(text.slice(esc));
+      break;
+    }
+
+    const body = text.slice(esc + 2, end);
+    if (/^[0-9;]*$/.test(body)) {
+      applySgr(body);
+    } else {
+      html += escapeHtml(text.slice(esc, end + 1));
+    }
+    index = end + 1;
+  }
+  return html;
+}
+
+function renderTerminalBlock(text) {
+  return `<pre class="roc-terminal">${renderAnsiTerminal(text)}</pre>`;
+}
+
 const ROC_TOKEN_NAMES = `
   EndOfFile Float StringStart StringEnd MultilineStringStart StringPart MalformedStringPart
   SingleQuote MalformedSingleQuote Int MalformedNumberBadSuffix MalformedNumberUnicodeSuffix
@@ -1151,9 +1249,7 @@ function setupExample(div) {
       wasmInstance.exports.compileAndRun(ptr, encoded.length);
     } catch (err) {
       captured.compilerMessages +=
-        '<div class="report error"><h1>Compiler crashed</h1><pre>' +
-        escapeHtml(String(err)) +
-        "</pre></div>";
+        "\x1b[1;31mCompiler crashed\x1b[0m\n" + String(err) + "\n";
       trapped = true;
     }
 
@@ -1161,12 +1257,11 @@ function setupExample(div) {
 
     // ---- 3. display results ----
     let html = "";
-    if (captured.compilerMessages) html += captured.compilerMessages;
+    if (captured.compilerMessages) html += renderTerminalBlock(captured.compilerMessages);
     if (captured.programOutput) {
       html +=
-        '<span class="roc-output-label">Output:\n</span><pre>' +
-        escapeHtml(captured.programOutput) +
-        "</pre>";
+        '<span class="roc-output-label">Output:\n</span>' +
+        renderTerminalBlock(captured.programOutput);
     }
     outputArea.innerHTML = html || "(no output)";
     outputArea.classList.remove("running");

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -1,141 +1,127 @@
 // main.js — Roc interactive examples (lazy-loads compiler on first Run click)
 "use strict";
 
-const utf8Decode = (bytes) => new TextDecoder().decode(bytes);
-const utf8Encode = (str) => new TextEncoder().encode(str);
+const decode = (bytes) => new TextDecoder().decode(bytes);
+const encode = (str) => new TextEncoder().encode(str);
 
 // All null until the user clicks "Run" for the first time.
 
-let wasmModule = null; // WebAssembly.Module
-let wasmInstance = null; // WebAssembly.Instance
-let wasmMemory = null; // WebAssembly.Memory
-let loadInProgress = null; // Promise | null — guards against concurrent loads
+let mod = null; // WebAssembly.Module
+let inst = null; // WebAssembly.Instance
+let mem = null; // WebAssembly.Memory
+let loading = null; // Promise | null — guards against concurrent loads
 
-// Every run creates a fresh { programOutput, compilerMessages } object
+// Every run creates a fresh { out, err } object
 // and stashes it here so the import callbacks can write into it.
-let runCapture = null;
+let capture = null;
 
 // Build a fresh imports object (needed for initial load & re-instantiation).
-function buildImports() {
+function imports() {
   return {
     env: {
       js_echo(ptr, len) {
-        if (runCapture) {
-          const slice = new Uint8Array(wasmMemory.buffer, ptr, len);
-          runCapture.programOutput += utf8Decode(slice);
+        if (capture) {
+          const slice = new Uint8Array(mem.buffer, ptr, len);
+          capture.out += decode(slice);
         }
       },
       js_stderr(ptr, len) {
-        if (runCapture) {
-          const slice = new Uint8Array(wasmMemory.buffer, ptr, len);
-          runCapture.compilerMessages += utf8Decode(slice);
+        if (capture) {
+          const slice = new Uint8Array(mem.buffer, ptr, len);
+          capture.err += decode(slice);
         }
       },
     },
   };
 }
 
-async function loadCompiler() {
-  if (wasmInstance) return; // already loaded
-  if (loadInProgress) return loadInProgress; // another click is loading it
+async function load() {
+  if (inst) return; // already loaded
+  if (loading) return loading; // another click is loading it
 
-  loadInProgress = (async () => {
+  loading = (async () => {
     const response = await fetch("echo.wasm", { priority: "low" });
     const { module, instance } = await WebAssembly.instantiateStreaming(
       response,
-      buildImports(),
+      imports(),
     );
-    wasmModule = module;
-    wasmInstance = instance;
-    wasmMemory = instance.exports.memory;
-    wasmInstance.exports.init();
+    mod = module;
+    inst = instance;
+    mem = instance.exports.memory;
+    inst.exports.init();
   })();
 
-  await loadInProgress;
-  loadInProgress = null;
+  await loading;
+  loading = null;
 }
 
-async function recoverCompiler() {
+async function recover() {
   try {
-    const instance = await WebAssembly.instantiate(wasmModule, buildImports());
-    wasmInstance = instance;
-    wasmMemory = instance.exports.memory;
-    wasmInstance.exports.init();
+    const instance = await WebAssembly.instantiate(mod, imports());
+    inst = instance;
+    mem = instance.exports.memory;
+    inst.exports.init();
   } catch (_) {
     // best-effort — if recovery fails the next run will show the error
   }
 }
 
-function escapeHtml(text) {
+function htmlEscape(text) {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
 }
 
-const ANSI_COLOR_CLASSES = [
-  "black",
-  "red",
-  "green",
-  "yellow",
-  "blue",
-  "magenta",
-  "cyan",
-  "white",
-];
+const ANSI_COLOR_CLASSES = "c e n k k k n v".split(" ");
 
-function renderAnsiTerminal(text) {
-  const state = { bold: false, dim: false, italic: false, underline: false, fg: null };
+function ansi(text) {
+  let bold = false;
+  let dim = false;
+  let italic = false;
+  let underline = false;
+  let fg = "";
 
   const classes = () => {
     const result = [];
-    if (state.bold) result.push("ansi-bold");
-    if (state.dim) result.push("ansi-dim");
-    if (state.italic) result.push("ansi-italic");
-    if (state.underline) result.push("ansi-underline");
-    if (state.fg) result.push(`ansi-fg-${state.fg}`);
+    if (bold) result.push("b");
+    if (dim) result.push("m");
+    if (italic) result.push("i");
+    if (underline) result.push("x");
+    if (fg) result.push(fg);
     return result.join(" ");
   };
 
   const span = (chunk) => {
     if (!chunk) return "";
     const cls = classes();
-    const escaped = escapeHtml(chunk);
+    const escaped = htmlEscape(chunk);
     return cls ? `<span class="${cls}">${escaped}</span>` : escaped;
   };
 
   const applySgr = (body) => {
-    const params = body === "" ? [0] : body.split(";").map(Number);
-    for (const code of params) {
-      if (!Number.isInteger(code)) continue;
-
+    for (const code of (body || "0").split(";").map(Number)) {
       if (code === 0) {
-        state.bold = false;
-        state.dim = false;
-        state.italic = false;
-        state.underline = false;
-        state.fg = null;
+        bold = dim = italic = underline = false;
+        fg = "";
       } else if (code === 1) {
-        state.bold = true;
+        bold = true;
       } else if (code === 2) {
-        state.dim = true;
+        dim = true;
       } else if (code === 3) {
-        state.italic = true;
+        italic = true;
       } else if (code === 4) {
-        state.underline = true;
+        underline = true;
       } else if (code === 22) {
-        state.bold = false;
-        state.dim = false;
+        bold = dim = false;
       } else if (code === 23) {
-        state.italic = false;
+        italic = false;
       } else if (code === 24) {
-        state.underline = false;
+        underline = false;
       } else if (code === 39) {
-        state.fg = null;
-      } else if (code >= 30 && code <= 37) {
-        state.fg = ANSI_COLOR_CLASSES[code - 30];
-      } else if (code >= 90 && code <= 97) {
-        state.fg = `bright-${ANSI_COLOR_CLASSES[code - 90]}`;
+        fg = "";
+      } else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+        fg = ANSI_COLOR_CLASSES[code % 10];
       }
     }
   };
@@ -152,7 +138,7 @@ function renderAnsiTerminal(text) {
     html += span(text.slice(index, esc));
     const end = text.indexOf("m", esc + 2);
     if (end === -1) {
-      html += escapeHtml(text.slice(esc));
+      html += htmlEscape(text.slice(esc));
       break;
     }
 
@@ -160,28 +146,28 @@ function renderAnsiTerminal(text) {
     if (/^[0-9;]*$/.test(body)) {
       applySgr(body);
     } else {
-      html += escapeHtml(text.slice(esc, end + 1));
+      html += htmlEscape(text.slice(esc, end + 1));
     }
     index = end + 1;
   }
   return html;
 }
 
-function renderTerminalBlock(text) {
-  return `<pre class="roc-terminal">${renderAnsiTerminal(text)}</pre>`;
+function terminal(text) {
+  return `<pre class="roc-terminal">${ansi(text)}</pre>`;
 }
 
 const TOK_CLASS = [
   null,
-  "upperident",
-  "lowerident",
-  "literal",
-  "string",
-  "keyword",
-  "punctuation",
-  "delimiter",
-  "op",
-  "error",
+  "u",
+  "v",
+  "n",
+  "s",
+  "k",
+  "p",
+  "d",
+  "o",
+  "e",
 ];
 const C_MASK = 15;
 const C_UPPER = 1;
@@ -225,77 +211,71 @@ const T_DOT_OP = C_OP | F_DOT_PREFIX;
 const T_DOT_ERROR = C_ERROR | F_EXPR_END | F_DOT_PREFIX;
 const T_DOTDOT_OP = C_OP | F_DOTDOT_PREFIX;
 
-const TWO_BYTE_TOKENS = new Map([
-  [0x213d, T_OP], // !=
-  [0x3f3f, T_OP], // ??
-  [0x7c3e, T_OP], // |>
-  [0x2f2f, T_OP], // //
-  [0x3e3d, T_OP], // >=
-  [0x3c3d, T_OP], // <=
-  [0x3c2d, T_OP_FIELD_PREFIX], // <-
-  [0x3d3d, T_OP], // ==
-  [0x3d3e, T_OP], // =>
-  [0x3a3d, T_OP], // :=
-  [0x3a3a, T_OP], // ::
-]);
+const TWO_BYTE_TOKENS = {
+  0x213d: T_OP, // !=
+  0x3f3f: T_OP, // ??
+  0x7c3e: T_OP, // |>
+  0x2f2f: T_OP, // //
+  0x3e3d: T_OP, // >=
+  0x3c3d: T_OP, // <=
+  0x3c2d: T_OP_FIELD_PREFIX, // <-
+  0x3d3d: T_OP, // ==
+  0x3d3e: T_OP, // =>
+  0x3a3d: T_OP, // :=
+  0x3a3a: T_OP, // ::
+};
 
-const ONE_BYTE_TOKENS = new Map([
-  [33, T_OP], // !
-  [38, T_OP_FIELD_PREFIX], // &
-  [44, T_FIELD_PREFIX], // ,
-  [63, T_OP], // ?
-  [124, T_OP], // |
-  [43, T_OP], // +
-  [42, T_OP], // *
-  [47, T_OP], // /
-  [37, T_OP], // %
-  [94, T_OP], // ^
-  [62, T_OP], // >
-  [60, T_OP], // <
-  [61, T_OP], // =
-  [58, T_COLON], // :
-  [40, T_PUNCT], // (
-  [91, T_DELIM], // [
-  [123, T_FIELD_PREFIX], // {
-  [41, T_PUNCT_END], // )
-  [93, T_DELIM_END], // ]
-]);
+const ONE_BYTE_TOKENS = {
+  33: T_OP, // !
+  38: T_OP_FIELD_PREFIX, // &
+  44: T_FIELD_PREFIX, // ,
+  63: T_OP, // ?
+  124: T_OP, // |
+  43: T_OP, // +
+  42: T_OP, // *
+  47: T_OP, // /
+  37: T_OP, // %
+  94: T_OP, // ^
+  62: T_OP, // >
+  60: T_OP, // <
+  61: T_OP, // =
+  58: T_COLON, // :
+  40: T_PUNCT, // (
+  91: T_DELIM, // [
+  123: T_FIELD_PREFIX, // {
+  41: T_PUNCT_END, // )
+  93: T_DELIM_END, // ]
+};
 
-const ROC_KEYWORDS = new Map([
-  ["and", T_OP],
-  ["or", T_OP],
-  ..."app as crash dbg else expect exposes exposing for generates has hosted if implements import imports in interface match module package packages platform provides requires return targets var where while with break"
-    .split(/\s+/)
-    .map((word) => [word, T_KEYWORD]),
-]);
+const ROC_KEYWORDS =
+  " app as crash dbg else expect exposes exposing for generates has hosted if implements import imports in interface match module package packages platform provides requires return targets var where while with break ";
+const ROC_NUMBER_SUFFIXES = " dec f32 f64 i128 i16 i32 i64 i8 nat u128 u16 u32 u64 u8 ";
 
-const ROC_NUMBER_SUFFIXES = new Set("dec f32 f64 i128 i16 i32 i64 i8 nat u128 u16 u32 u64 u8".split(" "));
-
-function isRocTokenError(tok) {
+function tokenError(tok) {
   return (tok & C_MASK) === C_ERROR;
 }
 
-function updateIfNotMalformed(tok, next) {
-  return isRocTokenError(tok) ? tok : next;
+function keepError(tok, next) {
+  return tokenError(tok) ? tok : next;
 }
 
-function isAsciiLower(c) {
+function lo(c) {
   return c >= 97 && c <= 122;
 }
 
-function isAsciiUpper(c) {
+function up(c) {
   return c >= 65 && c <= 90;
 }
 
-function isAsciiDigit(c) {
+function dig(c) {
   return c >= 48 && c <= 57;
 }
 
-function isHexDigit(c) {
-  return isAsciiDigit(c) || (c >= 97 && c <= 102) || (c >= 65 && c <= 70);
+function hex(c) {
+  return dig(c) || (c >= 97 && c <= 102) || (c >= 65 && c <= 70);
 }
 
-function utf8SequenceLength(c) {
+function u8len(c) {
   if (c < 0x80) return 1;
   if (c >= 0xc2 && c <= 0xdf) return 2;
   if (c >= 0xe0 && c <= 0xef) return 3;
@@ -303,121 +283,121 @@ function utf8SequenceLength(c) {
   return null;
 }
 
-function isValidUnicodeCodepoint(codepoint) {
+function validCp(codepoint) {
   return codepoint <= 0x10ffff && !(codepoint >= 0xd800 && codepoint <= 0xdfff);
 }
 
 class RocCursor {
   constructor(text) {
-    this.buf = utf8Encode(text);
-    this.pos = 0;
-    this.commentRanges = [];
+    this.b = encode(text);
+    this.p = 0;
+    this.r = [];
   }
 
-  peek() {
-    return this.pos < this.buf.length ? this.buf[this.pos] : null;
+  pk() {
+    return this.p < this.b.length ? this.b[this.p] : null;
   }
 
-  peekAt(lookahead) {
-    const idx = this.pos + lookahead;
-    return idx < this.buf.length ? this.buf[idx] : null;
+  at(lookahead) {
+    const idx = this.p + lookahead;
+    return idx < this.b.length ? this.b[idx] : null;
   }
 
-  isPeekedCharInRange(lookahead, start, end) {
-    const peeked = this.peekAt(lookahead);
+  inRange(lookahead, start, end) {
+    const peeked = this.at(lookahead);
     return peeked != null && peeked >= start && peeked <= end;
   }
 
-  chompTrivia() {
-    while (this.pos < this.buf.length) {
-      const b = this.buf[this.pos];
+  trivia() {
+    while (this.p < this.b.length) {
+      const b = this.b[this.p];
       if (b === 32 || b === 9 || b === 10) {
-        this.pos += 1;
+        this.p += 1;
       } else if (b === 13) {
-        this.pos += 1;
-        if (this.pos < this.buf.length && this.buf[this.pos] === 10) {
-          this.pos += 1;
+        this.p += 1;
+        if (this.p < this.b.length && this.b[this.p] === 10) {
+          this.p += 1;
         }
       } else if (b === 35) {
-        const start = this.pos;
-        this.pos += 1;
+        const start = this.p;
+        this.p += 1;
         while (
-          this.pos < this.buf.length &&
-          this.buf[this.pos] !== 10 &&
-          this.buf[this.pos] !== 13
+          this.p < this.b.length &&
+          this.b[this.p] !== 10 &&
+          this.b[this.p] !== 13
         ) {
-          this.pos += 1;
+          this.p += 1;
         }
-        this.commentRanges.push({ start, end: this.pos, className: "comment" });
+        this.r.push({ s: start, e: this.p, c: "c" });
       } else if (b >= 0 && b <= 31) {
-        this.pos += 1;
+        this.p += 1;
       } else {
         break;
       }
     }
   }
 
-  chompNumber() {
-    const initialDigit = this.buf[this.pos];
-    this.pos += 1;
+  number() {
+    const initialDigit = this.b[this.p];
+    this.p += 1;
 
     let tok = T_LITERAL;
     if (initialDigit === 48) {
       while (true) {
-        const c = this.peek() ?? 0;
+        const c = this.pk() ?? 0;
         if (c === 120 || c === 88) {
-          this.pos += 1;
-          if (!this.chompIntegerBase16()) {
+          this.p += 1;
+          if (!this.int16()) {
             tok = T_ERROR_END;
           }
-          tok = this.chompNumberSuffix(tok);
+          tok = this.suffix(tok);
           break;
         } else if (c === 111 || c === 79) {
-          this.pos += 1;
-          if (!this.chompIntegerBase8()) {
+          this.p += 1;
+          if (!this.int8()) {
             tok = T_ERROR_END;
           }
-          tok = this.chompNumberSuffix(tok);
+          tok = this.suffix(tok);
           break;
         } else if (c === 98 || c === 66) {
-          this.pos += 1;
-          if (!this.chompIntegerBase2()) {
+          this.p += 1;
+          if (!this.int2()) {
             tok = T_ERROR_END;
           }
-          tok = this.chompNumberSuffix(tok);
+          tok = this.suffix(tok);
           break;
-        } else if (isAsciiDigit(c)) {
-          tok = this.chompNumberBase10();
-          tok = this.chompNumberSuffix(tok);
+        } else if (dig(c)) {
+          tok = this.num10();
+          tok = this.suffix(tok);
           break;
         } else if (c === 95) {
-          this.pos += 1;
+          this.p += 1;
         } else if (c === 46) {
-          this.pos -= 1;
-          tok = this.chompNumberBase10();
-          tok = this.chompNumberSuffix(tok);
+          this.p -= 1;
+          tok = this.num10();
+          tok = this.suffix(tok);
           break;
         } else {
-          tok = this.chompNumberSuffix(tok);
+          tok = this.suffix(tok);
           break;
         }
       }
     } else {
-      tok = this.chompNumberBase10();
-      tok = this.chompNumberSuffix(tok);
+      tok = this.num10();
+      tok = this.suffix(tok);
     }
     return tok;
   }
 
-  chompExponent() {
-    const c = this.peek() ?? 0;
+  exp() {
+    const c = this.pk() ?? 0;
     if (c === 101 || c === 69) {
-      this.pos += 1;
-      const sign = this.peek() ?? 0;
+      this.p += 1;
+      const sign = this.pk() ?? 0;
       if (sign === 43 || sign === 45) {
-        this.pos += 1;
+        this.p += 1;
       }
-      if (!this.chompIntegerBase10()) {
+      if (!this.int10()) {
         return "EmptyExponent";
       }
       return true;
@@ -425,15 +405,15 @@ class RocCursor {
     return false;
   }
 
-  chompNumberSuffix(hypothesis) {
-    const c = this.peek();
+  suffix(hypothesis) {
+    const c = this.pk();
     if (c == null) {
       return hypothesis;
     }
     const isIdentChar =
-      isAsciiLower(c) ||
-      isAsciiUpper(c) ||
-      isAsciiDigit(c) ||
+      lo(c) ||
+      up(c) ||
+      dig(c) ||
       c === 95 ||
       c === 36 ||
       c >= 0x80;
@@ -441,32 +421,32 @@ class RocCursor {
       return hypothesis;
     }
 
-    const start = this.pos;
-    if (!this.chompIdentGeneral()) {
-      return updateIfNotMalformed(hypothesis, T_ERROR_END);
+    const start = this.p;
+    if (!this.ident()) {
+      return keepError(hypothesis, T_ERROR_END);
     }
-    const suffix = utf8Decode(this.buf.subarray(start, this.pos));
-    if (!ROC_NUMBER_SUFFIXES.has(suffix)) {
-      return updateIfNotMalformed(hypothesis, T_ERROR_END);
+    const suffix = decode(this.b.subarray(start, this.p));
+    if (!ROC_NUMBER_SUFFIXES.includes(" " + suffix + " ")) {
+      return keepError(hypothesis, T_ERROR_END);
     }
     return hypothesis;
   }
 
-  chompNumberBase10() {
+  num10() {
     let tokenType = T_LITERAL;
-    this.chompIntegerBase10();
+    this.int10();
     if (
-      (this.peek() ?? 0) === 46 &&
-      (this.isPeekedCharInRange(1, 48, 57) ||
-        this.peekAt(1) === 101 ||
-        this.peekAt(1) === 69)
+      (this.pk() ?? 0) === 46 &&
+      (this.inRange(1, 48, 57) ||
+        this.at(1) === 101 ||
+        this.at(1) === 69)
     ) {
-      this.pos += 1;
-      this.chompIntegerBase10();
+      this.p += 1;
+      this.int10();
       tokenType = T_LITERAL;
     }
 
-    const hasExponent = this.chompExponent();
+    const hasExponent = this.exp();
     if (hasExponent === "EmptyExponent") {
       return T_ERROR_END;
     }
@@ -476,15 +456,15 @@ class RocCursor {
     return tokenType;
   }
 
-  chompIntegerBase10() {
+  int10() {
     let containsDigits = false;
-    while (this.peek() != null) {
-      const c = this.peek();
-      if (isAsciiDigit(c)) {
+    while (this.pk() != null) {
+      const c = this.pk();
+      if (dig(c)) {
         containsDigits = true;
-        this.pos += 1;
+        this.p += 1;
       } else if (c === 95) {
-        this.pos += 1;
+        this.p += 1;
       } else {
         break;
       }
@@ -492,15 +472,15 @@ class RocCursor {
     return containsDigits;
   }
 
-  chompIntegerBase16() {
+  int16() {
     let containsDigits = false;
-    while (this.peek() != null) {
-      const c = this.peek();
-      if (isHexDigit(c)) {
+    while (this.pk() != null) {
+      const c = this.pk();
+      if (hex(c)) {
         containsDigits = true;
-        this.pos += 1;
+        this.p += 1;
       } else if (c === 95) {
-        this.pos += 1;
+        this.p += 1;
       } else {
         break;
       }
@@ -508,15 +488,15 @@ class RocCursor {
     return containsDigits;
   }
 
-  chompIntegerBase8() {
+  int8() {
     let containsDigits = false;
-    while (this.peek() != null) {
-      const c = this.peek();
+    while (this.pk() != null) {
+      const c = this.pk();
       if (c >= 48 && c <= 55) {
         containsDigits = true;
-        this.pos += 1;
+        this.p += 1;
       } else if (c === 95) {
-        this.pos += 1;
+        this.p += 1;
       } else {
         break;
       }
@@ -524,15 +504,15 @@ class RocCursor {
     return containsDigits;
   }
 
-  chompIntegerBase2() {
+  int2() {
     let containsDigits = false;
-    while (this.peek() != null) {
-      const c = this.peek();
+    while (this.pk() != null) {
+      const c = this.pk();
       if (c === 48 || c === 49) {
         containsDigits = true;
-        this.pos += 1;
+        this.p += 1;
       } else if (c === 95) {
-        this.pos += 1;
+        this.p += 1;
       } else {
         break;
       }
@@ -540,31 +520,34 @@ class RocCursor {
     return containsDigits;
   }
 
-  chompIdentLower() {
-    const start = this.pos;
-    if (!this.chompIdentGeneral()) {
+  lower() {
+    const start = this.p;
+    if (!this.ident()) {
       return T_ERROR_END;
     }
-    const ident = utf8Decode(this.buf.subarray(start, this.pos));
-    return ROC_KEYWORDS.get(ident) ?? T_LOWER;
+    const ident = decode(this.b.subarray(start, this.p));
+    if (ident === "and" || ident === "or") {
+      return T_OP;
+    }
+    return ROC_KEYWORDS.includes(" " + ident + " ") ? T_KEYWORD : T_LOWER;
   }
 
-  chompIdentGeneral() {
+  ident() {
     let valid = true;
-    while (this.pos < this.buf.length) {
-      const c = this.buf[this.pos];
+    while (this.p < this.b.length) {
+      const c = this.b[this.p];
       if (
-        isAsciiLower(c) ||
-        isAsciiUpper(c) ||
-        isAsciiDigit(c) ||
+        lo(c) ||
+        up(c) ||
+        dig(c) ||
         c === 95 ||
         c === 33 ||
         c === 36
       ) {
-        this.pos += 1;
+        this.p += 1;
       } else if (c >= 0x80) {
         valid = false;
-        this.pos += 1;
+        this.p += 1;
       } else {
         break;
       }
@@ -572,54 +555,54 @@ class RocCursor {
     return valid;
   }
 
-  chompInteger() {
-    while (this.pos < this.buf.length && isAsciiDigit(this.buf[this.pos])) {
-      this.pos += 1;
+  integer() {
+    while (this.p < this.b.length && dig(this.b[this.p])) {
+      this.p += 1;
     }
   }
 
-  chompEscapeSequenceWithQuote(quoteChar) {
-    const c = this.peek() ?? 0;
+  escape(quoteChar) {
+    const c = this.pk() ?? 0;
 
     if (c === 92 || c === 34 || c === 39 || c === 110 || c === 114 || c === 116 || c === 36) {
-      this.pos += 1;
+      this.p += 1;
       return true;
     }
 
     if (c === 117) {
-      this.pos += 1;
-      if (this.peek() === 40) {
-        this.pos += 1;
+      this.p += 1;
+      if (this.pk() === 40) {
+        this.p += 1;
       } else {
         return "InvalidUnicodeEscapeSequence";
       }
 
-      const hexStart = this.pos;
+      const hexStart = this.p;
       while (true) {
-        if (this.peek() === 41) {
-          if (this.pos === hexStart) {
-            this.pos += 1;
+        if (this.pk() === 41) {
+          if (this.p === hexStart) {
+            this.p += 1;
             return "InvalidUnicodeEscapeSequence";
           }
-          this.pos += 1;
+          this.p += 1;
           break;
-        } else if (this.peek() != null) {
-          const next = this.peek();
-          if (isHexDigit(next)) {
-            this.pos += 1;
+        } else if (this.pk() != null) {
+          const next = this.pk();
+          if (hex(next)) {
+            this.p += 1;
           } else {
-            while (this.pos < this.buf.length) {
-              const nextChar = this.peek() ?? 0;
+            while (this.p < this.b.length) {
+              const nextChar = this.pk() ?? 0;
               if (nextChar === 41 || nextChar === 10) {
                 break;
               }
               if (quoteChar != null && nextChar === quoteChar) {
                 break;
               }
-              this.pos += 1;
+              this.p += 1;
             }
-            if (this.pos < this.buf.length && this.peek() === 41) {
-              this.pos += 1;
+            if (this.p < this.b.length && this.pk() === 41) {
+              this.p += 1;
             }
             return "InvalidUnicodeEscapeSequence";
           }
@@ -628,9 +611,9 @@ class RocCursor {
         }
       }
 
-      const hexCode = utf8Decode(this.buf.subarray(hexStart, this.pos - 1));
+      const hexCode = decode(this.b.subarray(hexStart, this.p - 1));
       const codepoint = Number.parseInt(hexCode, 16);
-      if (!Number.isFinite(codepoint) || !isValidUnicodeCodepoint(codepoint)) {
+      if (!Number.isFinite(codepoint) || !validCp(codepoint)) {
         return "InvalidUnicodeEscapeSequence";
       }
 
@@ -640,17 +623,17 @@ class RocCursor {
     return "InvalidEscapeSequence";
   }
 
-  chompSingleQuoteLiteral() {
-    this.pos += 1;
+  single() {
+    this.p += 1;
     let state = "Empty";
 
-    while (this.pos < this.buf.length) {
-      const c = this.buf[this.pos];
+    while (this.p < this.b.length) {
+      const c = this.b[this.p];
       if (c === 10) {
         break;
       }
 
-      this.pos += 1;
+      this.p += 1;
 
       if (state === "Empty") {
         if (c === 39) {
@@ -658,12 +641,12 @@ class RocCursor {
         }
         if (c === 92) {
           state = "Enough";
-          if (this.chompEscapeSequenceWithQuote(39) !== true) {
+          if (this.escape(39) !== true) {
             state = "Invalid";
           }
         } else {
-          this.pos -= 1;
-          this.chompUTF8CodepointWithValidation();
+          this.p -= 1;
+          this.utf8();
           state = "Enough";
         }
       } else if (state === "Enough") {
@@ -683,71 +666,71 @@ class RocCursor {
     return T_ERROR_END;
   }
 
-  chompUTF8CodepointWithValidation() {
-    const c = this.buf[this.pos];
+  utf8() {
+    const c = this.b[this.p];
 
     if (c < 0x80) {
-      this.pos += 1;
+      this.p += 1;
       return c;
     }
 
-    const utf8Len = utf8SequenceLength(c);
-    if (utf8Len == null || this.pos + utf8Len > this.buf.length) {
-      this.pos += 1;
+    const utf8Len = u8len(c);
+    if (utf8Len == null || this.p + utf8Len > this.b.length) {
+      this.p += 1;
       return null;
     }
 
     let codepoint;
     if (utf8Len === 2) {
-      codepoint = ((c & 0x1f) << 6) | (this.buf[this.pos + 1] & 0x3f);
+      codepoint = ((c & 0x1f) << 6) | (this.b[this.p + 1] & 0x3f);
     } else if (utf8Len === 3) {
       codepoint =
         ((c & 0x0f) << 12) |
-        ((this.buf[this.pos + 1] & 0x3f) << 6) |
-        (this.buf[this.pos + 2] & 0x3f);
+        ((this.b[this.p + 1] & 0x3f) << 6) |
+        (this.b[this.p + 2] & 0x3f);
     } else {
       codepoint =
         ((c & 0x07) << 18) |
-        ((this.buf[this.pos + 1] & 0x3f) << 12) |
-        ((this.buf[this.pos + 2] & 0x3f) << 6) |
-        (this.buf[this.pos + 3] & 0x3f);
+        ((this.b[this.p + 1] & 0x3f) << 12) |
+        ((this.b[this.p + 2] & 0x3f) << 6) |
+        (this.b[this.p + 3] & 0x3f);
     }
 
-    this.pos += utf8Len;
+    this.p += utf8Len;
     return codepoint;
   }
 }
 
 class RocTokenizer {
   constructor(text) {
-    this.cursor = new RocCursor(text);
-    this.tokens = [];
-    this.stringInterpolationStack = [];
+    this.c = new RocCursor(text);
+    this.t = [];
+    this.s = [];
   }
 
-  lastTokenTag() {
-    return this.tokens.length === 0 ? null : this.tokens[this.tokens.length - 1].tag;
+  last() {
+    return this.t.length === 0 ? null : this.t[this.t.length - 1].t;
   }
 
-  pushToken(tag, start) {
-    this.tokens.push({ tag, start, end: this.cursor.pos });
+  push(tag, start) {
+    this.t.push({ t: tag, s: start, e: this.c.p });
   }
 
-  tokenizeKnownSymbol(start, b) {
-    const next = this.cursor.peekAt(1);
+  symbol(start, b) {
+    const next = this.c.at(1);
     if (next != null) {
-      const pairTag = TWO_BYTE_TOKENS.get((b << 8) | next);
+      const pairTag = TWO_BYTE_TOKENS[(b << 8) | next];
       if (pairTag != null) {
-        this.cursor.pos += 2;
-        this.pushToken(pairTag, start);
+        this.c.p += 2;
+        this.push(pairTag, start);
         return true;
       }
     }
 
-    const tag = ONE_BYTE_TOKENS.get(b);
+    const tag = ONE_BYTE_TOKENS[b];
     if (tag != null) {
-      this.cursor.pos += 1;
-      this.pushToken(tag, start);
+      this.c.p += 1;
+      this.push(tag, start);
       return true;
     }
 
@@ -757,297 +740,297 @@ class RocTokenizer {
   tokenize() {
     let sawWhitespace = true;
 
-    while (this.cursor.pos < this.cursor.buf.length) {
-      const start = this.cursor.pos;
+    while (this.c.p < this.c.b.length) {
+      const start = this.c.p;
       const sp = sawWhitespace;
       sawWhitespace = false;
-      const b = this.cursor.buf[this.cursor.pos];
+      const b = this.c.b[this.c.p];
 
       if (b <= 32 || b === 35) {
-        this.cursor.chompTrivia();
+        this.c.trivia();
         sawWhitespace = true;
       } else if (b === 46) {
-        this.tokenizeDot(start, sp);
+        this.dot(start, sp);
       } else if (b === 45) {
-        this.tokenizeMinus(start, sp);
+        this.minus(start, sp);
       } else if (b === 92) {
-        if (this.cursor.peekAt(1) === 92) {
-          this.tokenizeMultilineStringLiteral();
+        if (this.c.at(1) === 92) {
+          this.multiline();
         } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
+          this.c.p += 1;
+          this.push(T_OP, start);
         }
       } else if (b === 125) {
-        this.cursor.pos += 1;
-        if (this.stringInterpolationStack.length > 0) {
-          const last = this.stringInterpolationStack.pop();
-          this.pushToken(T_KEYWORD_END, start);
-          this.tokenizeStringLikeLiteralBody(last);
+        this.c.p += 1;
+        if (this.s.length > 0) {
+          const last = this.s.pop();
+          this.push(T_KEYWORD_END, start);
+          this.stringBody(last);
         } else {
-          this.pushToken(T_PUNCT_END, start);
+          this.push(T_PUNCT_END, start);
         }
-      } else if (this.tokenizeKnownSymbol(start, b)) {
+      } else if (this.symbol(start, b)) {
         continue;
       } else if (b === 95) {
-        this.tokenizeUnderscore(start);
+        this.under(start);
       } else if (b === 64) {
-        this.tokenizeOpaqueName(start);
+        this.opaque(start);
       } else if (b === 36) {
-        this.tokenizeDollar(start);
-      } else if (isAsciiDigit(b)) {
-        const tag = this.cursor.chompNumber();
-        this.pushToken(tag, start);
-      } else if (isAsciiLower(b)) {
-        const tag = this.cursor.chompIdentLower();
-        this.pushToken(tag, start);
-      } else if (isAsciiUpper(b)) {
+        this.dollar(start);
+      } else if (dig(b)) {
+        const tag = this.c.number();
+        this.push(tag, start);
+      } else if (lo(b)) {
+        const tag = this.c.lower();
+        this.push(tag, start);
+      } else if (up(b)) {
         let tag = T_UPPER;
-        if (!this.cursor.chompIdentGeneral()) {
+        if (!this.c.ident()) {
           tag = T_ERROR_END;
         }
-        this.pushToken(tag, start);
+        this.push(tag, start);
       } else if (b === 39) {
-        const tag = this.cursor.chompSingleQuoteLiteral();
-        this.pushToken(tag, start);
+        const tag = this.c.single();
+        this.push(tag, start);
       } else if (b === 34) {
-        this.tokenizeStringLikeLiteral();
+        this.string();
       } else if (b >= 0x80) {
-        this.cursor.chompIdentGeneral();
-        this.pushToken(T_ERROR_END, start);
+        this.c.ident();
+        this.push(T_ERROR_END, start);
       } else {
-        this.cursor.pos += 1;
-        this.pushToken(T_ERROR, start);
+        this.c.p += 1;
+        this.push(T_ERROR, start);
       }
     }
 
-    this.pushToken(T_NONE, this.cursor.pos);
+    this.push(T_NONE, this.c.p);
     return {
-      tokens: this.tokens,
-      comments: this.cursor.commentRanges,
-      bytes: this.cursor.buf,
+      t: this.t,
+      c: this.c.r,
+      b: this.c.b,
     };
   }
 
-  tokenizeDot(start, sp) {
-    const next = this.cursor.peekAt(1);
+  dot(start, sp) {
+    const next = this.c.at(1);
     if (next == null) {
-      this.cursor.pos += 1;
-      this.pushToken(T_PUNCT, start);
+      this.c.p += 1;
+      this.push(T_PUNCT, start);
     } else if (next === 46) {
-      if (this.cursor.peekAt(2) === 46) {
-        this.cursor.pos += 3;
-        this.pushToken(T_PUNCT, start);
-      } else if (this.cursor.peekAt(2) === 60) {
-        this.cursor.pos += 3;
-        this.pushToken(T_DOTDOT_OP, start);
-      } else if (this.cursor.peekAt(2) === 61) {
-        this.cursor.pos += 3;
-        this.pushToken(T_DOTDOT_OP, start);
+      if (this.c.at(2) === 46) {
+        this.c.p += 3;
+        this.push(T_PUNCT, start);
+      } else if (this.c.at(2) === 60) {
+        this.c.p += 3;
+        this.push(T_DOTDOT_OP, start);
+      } else if (this.c.at(2) === 61) {
+        this.c.p += 3;
+        this.push(T_DOTDOT_OP, start);
       } else {
-        this.cursor.pos += 2;
-        this.pushToken(T_PUNCT, start);
+        this.c.p += 2;
+        this.push(T_PUNCT, start);
       }
-    } else if (isAsciiDigit(next)) {
-      this.cursor.pos += 1;
-      this.cursor.chompInteger();
-      this.pushToken(T_DOT_LITERAL, start);
-    } else if (isAsciiLower(next)) {
+    } else if (dig(next)) {
+      this.c.p += 1;
+      this.c.integer();
+      this.push(T_DOT_LITERAL, start);
+    } else if (lo(next)) {
       let tag = T_DOT_LOWER;
-      this.cursor.pos += 1;
-      if (!this.cursor.chompIdentGeneral()) {
+      this.c.p += 1;
+      if (!this.c.ident()) {
         tag = T_DOT_ERROR;
       }
-      this.pushToken(tag, start);
-    } else if (isAsciiUpper(next)) {
+      this.push(tag, start);
+    } else if (up(next)) {
       let tag = T_DOT_UPPER;
-      this.cursor.pos += 1;
-      if (!this.cursor.chompIdentGeneral()) {
+      this.c.p += 1;
+      if (!this.c.ident()) {
         tag = T_DOT_ERROR;
       }
-      this.pushToken(tag, start);
+      this.push(tag, start);
     } else if (next >= 0x80 && next <= 0xff) {
-      this.cursor.pos += 1;
-      this.cursor.chompIdentGeneral();
-      this.pushToken(T_DOT_ERROR, start);
+      this.c.p += 1;
+      this.c.ident();
+      this.push(T_DOT_ERROR, start);
     } else if (next === 123) {
-      this.cursor.pos += 1;
-      this.pushToken(T_PUNCT, start);
+      this.c.p += 1;
+      this.push(T_PUNCT, start);
     } else if (next === 42) {
-      this.cursor.pos += 2;
-      this.pushToken(T_DOT_OP, start);
+      this.c.p += 2;
+      this.push(T_DOT_OP, start);
     } else {
-      this.cursor.pos += 1;
-      this.pushToken(T_PUNCT, start);
+      this.c.p += 1;
+      this.push(T_PUNCT, start);
     }
   }
 
-  tokenizeMinus(start, sp) {
-    const next = this.cursor.peekAt(1);
+  minus(start, sp) {
+    const next = this.c.at(1);
     if (next == null) {
-      this.cursor.pos += 1;
-      this.pushToken(T_OP, start);
+      this.c.p += 1;
+      this.push(T_OP, start);
     } else if (next === 62) {
-      this.cursor.pos += 2;
-      this.pushToken(T_OP, start);
+      this.c.p += 2;
+      this.push(T_OP, start);
     } else if (next === 32 || next === 9 || next === 10 || next === 13 || next === 35) {
-      this.cursor.pos += 1;
-      this.pushToken(T_OP, start);
-    } else if (isAsciiDigit(next)) {
-      const prev = this.lastTokenTag();
+      this.c.p += 1;
+      this.push(T_OP, start);
+    } else if (dig(next)) {
+      const prev = this.last();
       if (!sp && prev != null && (prev & F_EXPR_END) !== 0) {
-        this.cursor.pos += 1;
-        this.pushToken(T_OP, start);
+        this.c.p += 1;
+        this.push(T_OP, start);
       } else {
-        this.cursor.pos += 1;
-        const tag = this.cursor.chompNumber();
-        this.pushToken(tag, start);
+        this.c.p += 1;
+        const tag = this.c.number();
+        this.push(tag, start);
       }
     } else {
-      this.cursor.pos += 1;
-      this.pushToken(T_OP, start);
+      this.c.p += 1;
+      this.push(T_OP, start);
     }
   }
 
-  tokenizeUnderscore(start) {
-    const next = this.cursor.peekAt(1);
-    if (next != null && (isAsciiLower(next) || isAsciiUpper(next) || isAsciiDigit(next))) {
+  under(start) {
+    const next = this.c.at(1);
+    if (next != null && (lo(next) || up(next) || dig(next))) {
       let tag = T_LOWER;
-      this.cursor.pos += 2;
-      if (!this.cursor.chompIdentGeneral()) {
+      this.c.p += 2;
+      if (!this.c.ident()) {
         tag = T_ERROR_END;
       }
-      this.pushToken(tag, start);
+      this.push(tag, start);
     } else {
-      this.cursor.pos += 1;
-      this.pushToken(T_NONE, start);
+      this.c.p += 1;
+      this.push(T_NONE, start);
     }
   }
 
-  tokenizeOpaqueName(start) {
+  opaque(start) {
     let tok = T_UPPER;
-    const next = this.cursor.peekAt(1);
+    const next = this.c.at(1);
     if (
       next != null &&
-      (isAsciiLower(next) || isAsciiUpper(next) || isAsciiDigit(next) || next === 95 || next >= 0x80)
+      (lo(next) || up(next) || dig(next) || next === 95 || next >= 0x80)
     ) {
-      this.cursor.pos += 1;
-      if (!this.cursor.chompIdentGeneral()) {
+      this.c.p += 1;
+      if (!this.c.ident()) {
         tok = T_ERROR_END;
       }
     } else {
       tok = T_ERROR;
-      this.cursor.pos += 1;
+      this.c.p += 1;
     }
-    this.pushToken(tok, start);
+    this.push(tok, start);
   }
 
-  tokenizeDollar(start) {
-    const next = this.cursor.peekAt(1);
-    if (next != null && isAsciiLower(next)) {
+  dollar(start) {
+    const next = this.c.at(1);
+    if (next != null && lo(next)) {
       let tag = T_LOWER;
-      this.cursor.pos += 1;
-      if (!this.cursor.chompIdentGeneral()) {
+      this.c.p += 1;
+      if (!this.c.ident()) {
         tag = T_ERROR_END;
       }
-      this.pushToken(tag, start);
-    } else if (next != null && isAsciiUpper(next)) {
+      this.push(tag, start);
+    } else if (next != null && up(next)) {
       let tag = T_UPPER;
-      this.cursor.pos += 1;
-      if (!this.cursor.chompIdentGeneral()) {
+      this.c.p += 1;
+      if (!this.c.ident()) {
         tag = T_ERROR_END;
       }
-      this.pushToken(tag, start);
+      this.push(tag, start);
     } else {
-      this.cursor.pos += 1;
-      this.pushToken(T_ERROR, start);
+      this.c.p += 1;
+      this.push(T_ERROR, start);
     }
   }
 
-  tokenizeStringLikeLiteral() {
-    const start = this.cursor.pos;
-    this.cursor.pos += 1;
+  string() {
+    const start = this.c.p;
+    this.c.p += 1;
     let kind = "single_line";
-    if (this.cursor.peek() === 34 && this.cursor.peekAt(1) === 34) {
-      this.cursor.pos += 2;
+    if (this.c.pk() === 34 && this.c.at(1) === 34) {
+      this.c.p += 2;
       kind = "multi_line";
-      this.pushToken(T_STRING, start);
+      this.push(T_STRING, start);
     } else {
-      this.pushToken(T_STRING, start);
+      this.push(T_STRING, start);
     }
-    this.tokenizeStringLikeLiteralBody(kind);
+    this.stringBody(kind);
   }
 
-  tokenizeMultilineStringLiteral() {
-    const start = this.cursor.pos;
-    this.cursor.pos += 2;
-    this.pushToken(T_STRING, start);
-    this.tokenizeStringLikeLiteralBody("multi_line");
+  multiline() {
+    const start = this.c.p;
+    this.c.p += 2;
+    this.push(T_STRING, start);
+    this.stringBody("multi_line");
   }
 
-  tokenizeStringLikeLiteralBody(kind) {
-    const start = this.cursor.pos;
+  stringBody(kind) {
+    const start = this.c.p;
     let stringPartTag = T_STRING;
-    while (this.cursor.pos < this.cursor.buf.length) {
-      const c = this.cursor.buf[this.cursor.pos];
-      if (c === 36 && this.cursor.peekAt(1) === 123) {
-        this.pushToken(stringPartTag, start);
-        const dollarStart = this.cursor.pos;
-        this.cursor.pos += 2;
-        this.pushToken(T_KEYWORD, dollarStart);
-        this.stringInterpolationStack.push(kind);
+    while (this.c.p < this.c.b.length) {
+      const c = this.c.b[this.c.p];
+      if (c === 36 && this.c.at(1) === 123) {
+        this.push(stringPartTag, start);
+        const dollarStart = this.c.p;
+        this.c.p += 2;
+        this.push(T_KEYWORD, dollarStart);
+        this.s.push(kind);
         return;
       } else if (c === 10) {
-        this.pushToken(stringPartTag, start);
+        this.push(stringPartTag, start);
         if (kind === "single_line") {
-          this.pushToken(T_STRING_END, this.cursor.pos);
+          this.push(T_STRING_END, this.c.p);
         }
         return;
       } else if (kind === "single_line" && c === 34) {
-        this.pushToken(stringPartTag, start);
-        const stringPartEnd = this.cursor.pos;
-        this.cursor.pos += 1;
-        this.pushToken(T_STRING_END, stringPartEnd);
+        this.push(stringPartTag, start);
+        const stringPartEnd = this.c.p;
+        this.c.p += 1;
+        this.push(T_STRING_END, stringPartEnd);
         return;
       } else {
-        this.cursor.chompUTF8CodepointWithValidation();
-        if (c === 92 && this.cursor.chompEscapeSequenceWithQuote(34) !== true) {
+        this.c.utf8();
+        if (c === 92 && this.c.escape(34) !== true) {
           stringPartTag = T_ERROR;
         }
       }
     }
-    this.pushToken(stringPartTag, start);
+    this.push(stringPartTag, start);
   }
 }
 
-function tokenizeRocSource(source) {
+function rocTokens(source) {
   return new RocTokenizer(source).tokenize();
 }
 
-function classForRocToken(tag) {
+function tokenClass(tag) {
   return TOK_CLASS[tag & C_MASK];
 }
 
-function appendRocTokenHighlight(ranges, token) {
-  const className = classForRocToken(token.tag);
-  if (className == null) {
+function addToken(ranges, token) {
+  const cls = tokenClass(token.t);
+  if (cls == null) {
     return;
   }
 
-  if ((token.tag & F_DOT_PREFIX) !== 0 && token.start + 1 < token.end) {
-    ranges.push({ start: token.start, end: token.start + 1, className: "punctuation" });
-    ranges.push({ start: token.start + 1, end: token.end, className });
-  } else if ((token.tag & F_DOTDOT_PREFIX) !== 0 && token.start + 2 < token.end) {
-    ranges.push({ start: token.start, end: token.start + 2, className: "punctuation" });
-    ranges.push({ start: token.start + 2, end: token.end, className });
+  if ((token.t & F_DOT_PREFIX) !== 0 && token.s + 1 < token.e) {
+    ranges.push({ s: token.s, e: token.s + 1, c: "p" });
+    ranges.push({ s: token.s + 1, e: token.e, c: cls });
+  } else if ((token.t & F_DOTDOT_PREFIX) !== 0 && token.s + 2 < token.e) {
+    ranges.push({ s: token.s, e: token.s + 2, c: "p" });
+    ranges.push({ s: token.s + 2, e: token.e, c: cls });
   } else {
-    ranges.push({ start: token.start, end: token.end, className });
+    ranges.push({ s: token.s, e: token.e, c: cls });
   }
 }
 
-function renderHighlightedRocSource(source) {
-  const tokenized = tokenizeRocSource(source);
-  const ranges = [...tokenized.comments];
-  const tokens = tokenized.tokens.filter((token) => token.start !== token.end);
+function highlightRoc(source) {
+  const tokenized = rocTokens(source);
+  const ranges = [...tokenized.c];
+  const tokens = tokenized.t.filter((token) => token.s !== token.e);
 
   for (let i = 0; i < tokens.length; i += 1) {
     const previous = tokens[i - 1];
@@ -1056,39 +1039,39 @@ function renderHighlightedRocSource(source) {
     if (
       previous != null &&
       next != null &&
-      (previous.tag & F_FIELD_PREFIX) !== 0 &&
-      (token.tag & F_FIELD_NAME) !== 0 &&
-      (next.tag & F_COLON) !== 0 &&
-      utf8Decode(tokenized.bytes.subarray(token.end, next.start)).trim() === ""
+      (previous.t & F_FIELD_PREFIX) !== 0 &&
+      (token.t & F_FIELD_NAME) !== 0 &&
+      (next.t & F_COLON) !== 0 &&
+      decode(tokenized.b.subarray(token.e, next.s)).trim() === ""
     ) {
-      ranges.push({ start: token.start, end: next.end, className: "field" });
+      ranges.push({ s: token.s, e: next.e, c: "f" });
       i += 1;
     } else {
-      appendRocTokenHighlight(ranges, token);
+      addToken(ranges, token);
     }
   }
 
-  ranges.sort((a, b) => a.start - b.start || a.end - b.end);
+  ranges.sort((a, b) => a.s - b.s || a.e - b.e);
 
   let html = "";
   let lastEnd = 0;
   for (const range of ranges) {
-    if (range.start < lastEnd) {
+    if (range.s < lastEnd) {
       continue;
     }
-    html += escapeHtml(utf8Decode(tokenized.bytes.subarray(lastEnd, range.start)));
-    html += `<span class="${range.className}">`;
-    html += escapeHtml(utf8Decode(tokenized.bytes.subarray(range.start, range.end)));
+    html += htmlEscape(decode(tokenized.b.subarray(lastEnd, range.s)));
+    html += `<span class="${range.c}">`;
+    html += htmlEscape(decode(tokenized.b.subarray(range.s, range.e)));
     html += "</span>";
-    lastEnd = range.end;
+    lastEnd = range.e;
   }
-  html += escapeHtml(utf8Decode(tokenized.bytes.subarray(lastEnd)));
+  html += htmlEscape(decode(tokenized.b.subarray(lastEnd)));
   return html || " ";
 }
 
-function setupHighlightedSource(textarea, highlight) {
+function setupHighlight(textarea, highlight) {
   const updateHighlight = () => {
-    highlight.innerHTML = renderHighlightedRocSource(textarea.value);
+    highlight.innerHTML = highlightRoc(textarea.value);
   };
 
   const syncScroll = () => {
@@ -1103,7 +1086,7 @@ function setupHighlightedSource(textarea, highlight) {
   syncScroll();
 }
 
-function setupExample(div) {
+function setup(div) {
   // The Run button is added statically in the markup (so it shows even before
   // this script loads). Pull it out before reading the source so its label
   // doesn't end up in the Roc code, then reuse it below.
@@ -1126,7 +1109,7 @@ function setupExample(div) {
   const sourceHighlight = document.createElement("pre");
   sourceHighlight.className = "roc-source-highlight";
   sourceHighlight.setAttribute("aria-hidden", "true");
-  setupHighlightedSource(textarea, sourceHighlight);
+  setupHighlight(textarea, sourceHighlight);
 
   // Keep Tab from leaving the textarea
   textarea.addEventListener("keydown", (e) => {
@@ -1147,10 +1130,10 @@ function setupExample(div) {
 
   runButton.addEventListener("click", async () => {
     // ---- 1. lazy-load compiler on first click ----
-    if (!wasmInstance) {
+    if (!inst) {
       outputArea.textContent = "Loading compiler\u2026";
       try {
-        await loadCompiler();
+        await load();
       } catch (err) {
         outputArea.textContent = "Could not load the Roc compiler: " + err;
         return;
@@ -1162,40 +1145,40 @@ function setupExample(div) {
     outputArea.classList.add("running");
     runButton.disabled = true;
 
-    const captured = { programOutput: "", compilerMessages: "" };
-    runCapture = captured;
+    const captured = { out: "", err: "" };
+    capture = captured;
     let trapped = false;
 
     try {
-      wasmInstance.exports.init();
+      inst.exports.init();
 
-      const encoded = utf8Encode(textarea.value);
-      const ptr = wasmInstance.exports.allocateBuffer(encoded.length);
+      const encoded = encode(textarea.value);
+      const ptr = inst.exports.allocateBuffer(encoded.length);
       if (!ptr) throw new Error("allocateBuffer returned null");
-      new Uint8Array(wasmMemory.buffer, ptr, encoded.length).set(encoded);
+      new Uint8Array(mem.buffer, ptr, encoded.length).set(encoded);
 
-      wasmInstance.exports.compileAndRun(ptr, encoded.length);
+      inst.exports.compileAndRun(ptr, encoded.length);
     } catch (err) {
-      captured.compilerMessages +=
+      captured.err +=
         "\x1b[1;31mCompiler crashed\x1b[0m\n" + String(err) + "\n";
       trapped = true;
     }
 
-    runCapture = null;
+    capture = null;
 
     // ---- 3. display results ----
     let html = "";
-    if (captured.compilerMessages) html += renderTerminalBlock(captured.compilerMessages);
-    if (captured.programOutput) {
+    if (captured.err) html += terminal(captured.err);
+    if (captured.out) {
       html +=
         '<span class="roc-output-label">Output:\n</span>' +
-        renderTerminalBlock(captured.programOutput);
+        terminal(captured.out);
     }
     outputArea.innerHTML = html || "(no output)";
     outputArea.classList.remove("running");
 
     // ---- 4. recover from trap so later runs work ----
-    if (trapped) await recoverCompiler();
+    if (trapped) await recover();
 
     runButton.disabled = false;
   });
@@ -1209,11 +1192,11 @@ function setupExample(div) {
 
 // run the setup, when the DOM is finished loading
 document.addEventListener("DOMContentLoaded", () => {
-  document.querySelectorAll(".roc-interactive").forEach(setupExample);
+  document.querySelectorAll(".roc-interactive").forEach(setup);
 
   // Pre-download the compiler in the background at low priority so the first
   // Run click is instant. Errors are ignored here — the click handler retries.
-  const preload = () => loadCompiler().catch(() => {});
+  const preload = () => load().catch(() => {});
   if ("requestIdleCallback" in window) {
     requestIdleCallback(preload);
   } else {

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -225,6 +225,42 @@ const T_DOT_OP = C_OP | F_DOT_PREFIX;
 const T_DOT_ERROR = C_ERROR | F_EXPR_END | F_DOT_PREFIX;
 const T_DOTDOT_OP = C_OP | F_DOTDOT_PREFIX;
 
+const TWO_BYTE_TOKENS = new Map([
+  [0x213d, T_OP], // !=
+  [0x3f3f, T_OP], // ??
+  [0x7c3e, T_OP], // |>
+  [0x2f2f, T_OP], // //
+  [0x3e3d, T_OP], // >=
+  [0x3c3d, T_OP], // <=
+  [0x3c2d, T_OP_FIELD_PREFIX], // <-
+  [0x3d3d, T_OP], // ==
+  [0x3d3e, T_OP], // =>
+  [0x3a3d, T_OP], // :=
+  [0x3a3a, T_OP], // ::
+]);
+
+const ONE_BYTE_TOKENS = new Map([
+  [33, T_OP], // !
+  [38, T_OP_FIELD_PREFIX], // &
+  [44, T_FIELD_PREFIX], // ,
+  [63, T_OP], // ?
+  [124, T_OP], // |
+  [43, T_OP], // +
+  [42, T_OP], // *
+  [47, T_OP], // /
+  [37, T_OP], // %
+  [94, T_OP], // ^
+  [62, T_OP], // >
+  [60, T_OP], // <
+  [61, T_OP], // =
+  [58, T_COLON], // :
+  [40, T_PUNCT], // (
+  [91, T_DELIM], // [
+  [123, T_FIELD_PREFIX], // {
+  [41, T_PUNCT_END], // )
+  [93, T_DELIM_END], // ]
+]);
+
 const ROC_KEYWORDS = new Map([
   ["and", T_OP],
   ["or", T_OP],
@@ -257,10 +293,6 @@ function isAsciiDigit(c) {
 
 function isHexDigit(c) {
   return isAsciiDigit(c) || (c >= 97 && c <= 102) || (c >= 65 && c <= 70);
-}
-
-function canFollowUnaryMinus(c) {
-  return isAsciiLower(c) || isAsciiUpper(c) || c === 95 || c === 40 || c >= 0x80;
 }
 
 function utf8SequenceLength(c) {
@@ -701,6 +733,27 @@ class RocTokenizer {
     this.tokens.push({ tag, start, end: this.cursor.pos });
   }
 
+  tokenizeKnownSymbol(start, b) {
+    const next = this.cursor.peekAt(1);
+    if (next != null) {
+      const pairTag = TWO_BYTE_TOKENS.get((b << 8) | next);
+      if (pairTag != null) {
+        this.cursor.pos += 2;
+        this.pushToken(pairTag, start);
+        return true;
+      }
+    }
+
+    const tag = ONE_BYTE_TOKENS.get(b);
+    if (tag != null) {
+      this.cursor.pos += 1;
+      this.pushToken(tag, start);
+      return true;
+    }
+
+    return false;
+  }
+
   tokenize() {
     let sawWhitespace = true;
 
@@ -717,50 +770,6 @@ class RocTokenizer {
         this.tokenizeDot(start, sp);
       } else if (b === 45) {
         this.tokenizeMinus(start, sp);
-      } else if (b === 33) {
-        if (this.cursor.peekAt(1) === 61) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
-        }
-      } else if (b === 38) {
-        this.cursor.pos += 1;
-        this.pushToken(T_OP_FIELD_PREFIX, start);
-      } else if (b === 44) {
-        this.cursor.pos += 1;
-        this.pushToken(T_FIELD_PREFIX, start);
-      } else if (b === 63) {
-        if (this.cursor.peekAt(1) === 63) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
-        }
-      } else if (b === 124) {
-        if (this.cursor.peekAt(1) === 62) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
-        }
-      } else if (b === 43) {
-        this.cursor.pos += 1;
-        this.pushToken(T_OP, start);
-      } else if (b === 42) {
-        this.cursor.pos += 1;
-        this.pushToken(T_OP, start);
-      } else if (b === 47) {
-        if (this.cursor.peekAt(1) === 47) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
-        }
       } else if (b === 92) {
         if (this.cursor.peekAt(1) === 92) {
           this.tokenizeMultilineStringLiteral();
@@ -768,68 +777,6 @@ class RocTokenizer {
           this.cursor.pos += 1;
           this.pushToken(T_OP, start);
         }
-      } else if (b === 37) {
-        this.cursor.pos += 1;
-        this.pushToken(T_OP, start);
-      } else if (b === 94) {
-        this.cursor.pos += 1;
-        this.pushToken(T_OP, start);
-      } else if (b === 62) {
-        if (this.cursor.peekAt(1) === 61) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
-        }
-      } else if (b === 60) {
-        if (this.cursor.peekAt(1) === 61) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else if (this.cursor.peekAt(1) === 45) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP_FIELD_PREFIX, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
-        }
-      } else if (b === 61) {
-        if (this.cursor.peekAt(1) === 61) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else if (this.cursor.peekAt(1) === 62) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_OP, start);
-        }
-      } else if (b === 58) {
-        if (this.cursor.peekAt(1) === 61) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else if (this.cursor.peekAt(1) === 58) {
-          this.cursor.pos += 2;
-          this.pushToken(T_OP, start);
-        } else {
-          this.cursor.pos += 1;
-          this.pushToken(T_COLON, start);
-        }
-      } else if (b === 40) {
-        this.cursor.pos += 1;
-        this.pushToken(T_PUNCT, start);
-      } else if (b === 91) {
-        this.cursor.pos += 1;
-        this.pushToken(T_DELIM, start);
-      } else if (b === 123) {
-        this.cursor.pos += 1;
-        this.pushToken(T_FIELD_PREFIX, start);
-      } else if (b === 41) {
-        this.cursor.pos += 1;
-        this.pushToken(T_PUNCT_END, start);
-      } else if (b === 93) {
-        this.cursor.pos += 1;
-        this.pushToken(T_DELIM_END, start);
       } else if (b === 125) {
         this.cursor.pos += 1;
         if (this.stringInterpolationStack.length > 0) {
@@ -839,6 +786,8 @@ class RocTokenizer {
         } else {
           this.pushToken(T_PUNCT_END, start);
         }
+      } else if (this.tokenizeKnownSymbol(start, b)) {
+        continue;
       } else if (b === 95) {
         this.tokenizeUnderscore(start);
       } else if (b === 64) {

--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -157,102 +157,56 @@ function terminal(text) {
   return `<pre class="roc-terminal">${ansi(text)}</pre>`;
 }
 
-const TOK_CLASS = [
-  null,
-  "u",
-  "v",
-  "n",
-  "s",
-  "k",
-  "p",
-  "d",
-  "o",
-  "e",
-];
-const C_MASK = 15;
-const C_UPPER = 1;
-const C_LOWER = 2;
-const C_LITERAL = 3;
-const C_STRING = 4;
-const C_KEYWORD = 5;
-const C_PUNCT = 6;
-const C_DELIM = 7;
-const C_OP = 8;
-const C_ERROR = 9;
-const F_EXPR_END = 16;
-const F_FIELD_PREFIX = 32;
-const F_FIELD_NAME = 64;
-const F_DOT_PREFIX = 128;
-const F_DOTDOT_PREFIX = 256;
-const F_COLON = 512;
-
-const T_NONE = 0;
-const T_ERROR = C_ERROR;
-const T_ERROR_END = C_ERROR | F_EXPR_END;
-const T_UPPER = C_UPPER | F_EXPR_END;
-const T_LOWER = C_LOWER | F_EXPR_END | F_FIELD_NAME;
-const T_LITERAL = C_LITERAL | F_EXPR_END;
-const T_STRING = C_STRING;
-const T_STRING_END = C_STRING | F_EXPR_END;
-const T_KEYWORD = C_KEYWORD;
-const T_KEYWORD_END = C_KEYWORD | F_EXPR_END;
-const T_PUNCT = C_PUNCT;
-const T_PUNCT_END = C_PUNCT | F_EXPR_END;
-const T_FIELD_PREFIX = C_PUNCT | F_FIELD_PREFIX;
-const T_DELIM = C_DELIM;
-const T_DELIM_END = C_DELIM | F_EXPR_END;
-const T_OP = C_OP;
-const T_OP_FIELD_PREFIX = C_OP | F_FIELD_PREFIX;
-const T_COLON = C_OP | F_COLON;
-const T_DOT_LOWER = C_LOWER | F_EXPR_END | F_DOT_PREFIX;
-const T_DOT_UPPER = C_UPPER | F_EXPR_END | F_DOT_PREFIX;
-const T_DOT_LITERAL = C_LITERAL | F_EXPR_END | F_DOT_PREFIX;
-const T_DOT_OP = C_OP | F_DOT_PREFIX;
-const T_DOT_ERROR = C_ERROR | F_EXPR_END | F_DOT_PREFIX;
-const T_DOTDOT_OP = C_OP | F_DOTDOT_PREFIX;
+const CL = [null, "u", "v", "n", "s", "k", "p", "d", "o", "e", "c"];
+const M = 15, X = 16, A = 32, N = 64, B = 128, G = 256, H = 512;
+const Z = 0, ER = 9, EE = 25, U = 17, L = 82, NUM = 19, S = 4, SE = 20;
+const K = 5, KE = 21, P = 6, PE = 22, F = 38, D = 7, DE = 23, O = 8;
+const OF = 40, CO = 520, DL = 210, DU = 145, DN = 147, DO = 136;
+const DER = 153, DD = 264, CM = 10;
 
 const TWO_BYTE_TOKENS = {
-  0x213d: T_OP, // !=
-  0x3f3f: T_OP, // ??
-  0x7c3e: T_OP, // |>
-  0x2f2f: T_OP, // //
-  0x3e3d: T_OP, // >=
-  0x3c3d: T_OP, // <=
-  0x3c2d: T_OP_FIELD_PREFIX, // <-
-  0x3d3d: T_OP, // ==
-  0x3d3e: T_OP, // =>
-  0x3a3d: T_OP, // :=
-  0x3a3a: T_OP, // ::
+  0x213d: O, // !=
+  0x3f3f: O, // ??
+  0x7c3e: O, // |>
+  0x2f2f: O, // //
+  0x3e3d: O, // >=
+  0x3c3d: O, // <=
+  0x3c2d: OF, // <-
+  0x3d3d: O, // ==
+  0x3d3e: O, // =>
+  0x3a3d: O, // :=
+  0x3a3a: O, // ::
 };
 
 const ONE_BYTE_TOKENS = {
-  33: T_OP, // !
-  38: T_OP_FIELD_PREFIX, // &
-  44: T_FIELD_PREFIX, // ,
-  63: T_OP, // ?
-  124: T_OP, // |
-  43: T_OP, // +
-  42: T_OP, // *
-  47: T_OP, // /
-  37: T_OP, // %
-  94: T_OP, // ^
-  62: T_OP, // >
-  60: T_OP, // <
-  61: T_OP, // =
-  58: T_COLON, // :
-  40: T_PUNCT, // (
-  91: T_DELIM, // [
-  123: T_FIELD_PREFIX, // {
-  41: T_PUNCT_END, // )
-  93: T_DELIM_END, // ]
+  33: O, // !
+  38: OF, // &
+  44: F, // ,
+  63: O, // ?
+  124: O, // |
+  43: O, // +
+  42: O, // *
+  47: O, // /
+  37: O, // %
+  94: O, // ^
+  62: O, // >
+  60: O, // <
+  61: O, // =
+  58: CO, // :
+  40: P, // (
+  91: D, // [
+  123: F, // {
+  41: PE, // )
+  93: DE, // ]
 };
 
-const ROC_KEYWORDS =
-  " app as crash dbg else expect exposes exposing for generates has hosted if implements import imports in interface match module package packages platform provides requires return targets var where while with break ";
-const ROC_NUMBER_SUFFIXES = " dec f32 f64 i128 i16 i32 i64 i8 nat u128 u16 u32 u64 u8 ";
+const KWDS =
+  /^(app|as|crash|dbg|else|expect|exposes|exposing|for|generates|has|hosted|if|implements|import|imports|in|interface|match|module|package|packages|platform|provides|requires|return|targets|var|where|while|with|break)$/;
+const SUF =
+  /^(dec|f32|f64|i128|i16|i32|i64|i8|nat|u128|u16|u32|u64|u8)$/;
 
 function tokenError(tok) {
-  return (tok & C_MASK) === C_ERROR;
+  return (tok & M) === ER;
 }
 
 function keepError(tok, next) {
@@ -287,11 +241,12 @@ function validCp(codepoint) {
   return codepoint <= 0x10ffff && !(codepoint >= 0xd800 && codepoint <= 0xdfff);
 }
 
-class RocCursor {
+class RocTokenizer {
   constructor(text) {
     this.b = encode(text);
     this.p = 0;
-    this.r = [];
+    this.t = [];
+    this.s = [];
   }
 
   pk() {
@@ -328,7 +283,7 @@ class RocCursor {
         ) {
           this.p += 1;
         }
-        this.r.push({ s: start, e: this.p, c: "c" });
+        this.t.push([CM, start, this.p]);
       } else if (b >= 0 && b <= 31) {
         this.p += 1;
       } else {
@@ -341,28 +296,28 @@ class RocCursor {
     const initialDigit = this.b[this.p];
     this.p += 1;
 
-    let tok = T_LITERAL;
+    let tok = NUM;
     if (initialDigit === 48) {
       while (true) {
         const c = this.pk() ?? 0;
         if (c === 120 || c === 88) {
           this.p += 1;
           if (!this.int16()) {
-            tok = T_ERROR_END;
+            tok = EE;
           }
           tok = this.suffix(tok);
           break;
         } else if (c === 111 || c === 79) {
           this.p += 1;
           if (!this.int8()) {
-            tok = T_ERROR_END;
+            tok = EE;
           }
           tok = this.suffix(tok);
           break;
         } else if (c === 98 || c === 66) {
           this.p += 1;
           if (!this.int2()) {
-            tok = T_ERROR_END;
+            tok = EE;
           }
           tok = this.suffix(tok);
           break;
@@ -423,17 +378,17 @@ class RocCursor {
 
     const start = this.p;
     if (!this.ident()) {
-      return keepError(hypothesis, T_ERROR_END);
+      return keepError(hypothesis, EE);
     }
     const suffix = decode(this.b.subarray(start, this.p));
-    if (!ROC_NUMBER_SUFFIXES.includes(" " + suffix + " ")) {
-      return keepError(hypothesis, T_ERROR_END);
+    if (!SUF.test(suffix)) {
+      return keepError(hypothesis, EE);
     }
     return hypothesis;
   }
 
   num10() {
-    let tokenType = T_LITERAL;
+    let tokenType = NUM;
     this.int10();
     if (
       (this.pk() ?? 0) === 46 &&
@@ -443,15 +398,15 @@ class RocCursor {
     ) {
       this.p += 1;
       this.int10();
-      tokenType = T_LITERAL;
+      tokenType = NUM;
     }
 
     const hasExponent = this.exp();
     if (hasExponent === "EmptyExponent") {
-      return T_ERROR_END;
+      return EE;
     }
     if (hasExponent) {
-      tokenType = T_LITERAL;
+      tokenType = NUM;
     }
     return tokenType;
   }
@@ -523,13 +478,13 @@ class RocCursor {
   lower() {
     const start = this.p;
     if (!this.ident()) {
-      return T_ERROR_END;
+      return EE;
     }
     const ident = decode(this.b.subarray(start, this.p));
     if (ident === "and" || ident === "or") {
-      return T_OP;
+      return O;
     }
-    return ROC_KEYWORDS.includes(" " + ident + " ") ? T_KEYWORD : T_LOWER;
+    return KWDS.test(ident) ? K : L;
   }
 
   ident() {
@@ -637,7 +592,7 @@ class RocCursor {
 
       if (state === "Empty") {
         if (c === 39) {
-          return T_ERROR_END;
+          return EE;
         }
         if (c === 92) {
           state = "Enough";
@@ -651,19 +606,19 @@ class RocCursor {
         }
       } else if (state === "Enough") {
         if (c === 39) {
-          return T_STRING_END;
+          return SE;
         }
         state = "TooLong";
       } else if (state === "TooLong") {
         if (c === 39) {
-          return T_ERROR_END;
+          return EE;
         }
       } else if (state === "Invalid" && c === 39) {
-        return T_ERROR_END;
+        return EE;
       }
     }
 
-    return T_ERROR_END;
+    return EE;
   }
 
   utf8() {
@@ -699,29 +654,24 @@ class RocCursor {
     this.p += utf8Len;
     return codepoint;
   }
-}
-
-class RocTokenizer {
-  constructor(text) {
-    this.c = new RocCursor(text);
-    this.t = [];
-    this.s = [];
-  }
-
   last() {
-    return this.t.length === 0 ? null : this.t[this.t.length - 1].t;
+    for (let i = this.t.length - 1; i >= 0; i -= 1) {
+      const tag = this.t[i][0];
+      if (tag !== CM) return tag;
+    }
+    return null;
   }
 
   push(tag, start) {
-    this.t.push({ t: tag, s: start, e: this.c.p });
+    this.t.push([tag, start, this.p]);
   }
 
   symbol(start, b) {
-    const next = this.c.at(1);
+    const next = this.at(1);
     if (next != null) {
       const pairTag = TWO_BYTE_TOKENS[(b << 8) | next];
       if (pairTag != null) {
-        this.c.p += 2;
+        this.p += 2;
         this.push(pairTag, start);
         return true;
       }
@@ -729,7 +679,7 @@ class RocTokenizer {
 
     const tag = ONE_BYTE_TOKENS[b];
     if (tag != null) {
-      this.c.p += 1;
+      this.p += 1;
       this.push(tag, start);
       return true;
     }
@@ -740,34 +690,34 @@ class RocTokenizer {
   tokenize() {
     let sawWhitespace = true;
 
-    while (this.c.p < this.c.b.length) {
-      const start = this.c.p;
+    while (this.p < this.b.length) {
+      const start = this.p;
       const sp = sawWhitespace;
       sawWhitespace = false;
-      const b = this.c.b[this.c.p];
+      const b = this.b[this.p];
 
       if (b <= 32 || b === 35) {
-        this.c.trivia();
+        this.trivia();
         sawWhitespace = true;
       } else if (b === 46) {
         this.dot(start, sp);
       } else if (b === 45) {
         this.minus(start, sp);
       } else if (b === 92) {
-        if (this.c.at(1) === 92) {
+        if (this.at(1) === 92) {
           this.multiline();
         } else {
-          this.c.p += 1;
-          this.push(T_OP, start);
+          this.p += 1;
+          this.push(O, start);
         }
       } else if (b === 125) {
-        this.c.p += 1;
+        this.p += 1;
         if (this.s.length > 0) {
           const last = this.s.pop();
-          this.push(T_KEYWORD_END, start);
+          this.push(KE, start);
           this.stringBody(last);
         } else {
-          this.push(T_PUNCT_END, start);
+          this.push(PE, start);
         }
       } else if (this.symbol(start, b)) {
         continue;
@@ -778,223 +728,222 @@ class RocTokenizer {
       } else if (b === 36) {
         this.dollar(start);
       } else if (dig(b)) {
-        const tag = this.c.number();
+        const tag = this.number();
         this.push(tag, start);
       } else if (lo(b)) {
-        const tag = this.c.lower();
+        const tag = this.lower();
         this.push(tag, start);
       } else if (up(b)) {
-        let tag = T_UPPER;
-        if (!this.c.ident()) {
-          tag = T_ERROR_END;
+        let tag = U;
+        if (!this.ident()) {
+          tag = EE;
         }
         this.push(tag, start);
       } else if (b === 39) {
-        const tag = this.c.single();
+        const tag = this.single();
         this.push(tag, start);
       } else if (b === 34) {
         this.string();
       } else if (b >= 0x80) {
-        this.c.ident();
-        this.push(T_ERROR_END, start);
+        this.ident();
+        this.push(EE, start);
       } else {
-        this.c.p += 1;
-        this.push(T_ERROR, start);
+        this.p += 1;
+        this.push(ER, start);
       }
     }
 
-    this.push(T_NONE, this.c.p);
+    this.push(Z, this.p);
     return {
       t: this.t,
-      c: this.c.r,
-      b: this.c.b,
+      b: this.b,
     };
   }
 
   dot(start, sp) {
-    const next = this.c.at(1);
+    const next = this.at(1);
     if (next == null) {
-      this.c.p += 1;
-      this.push(T_PUNCT, start);
+      this.p += 1;
+      this.push(P, start);
     } else if (next === 46) {
-      if (this.c.at(2) === 46) {
-        this.c.p += 3;
-        this.push(T_PUNCT, start);
-      } else if (this.c.at(2) === 60) {
-        this.c.p += 3;
-        this.push(T_DOTDOT_OP, start);
-      } else if (this.c.at(2) === 61) {
-        this.c.p += 3;
-        this.push(T_DOTDOT_OP, start);
+      if (this.at(2) === 46) {
+        this.p += 3;
+        this.push(P, start);
+      } else if (this.at(2) === 60) {
+        this.p += 3;
+        this.push(DD, start);
+      } else if (this.at(2) === 61) {
+        this.p += 3;
+        this.push(DD, start);
       } else {
-        this.c.p += 2;
-        this.push(T_PUNCT, start);
+        this.p += 2;
+        this.push(P, start);
       }
     } else if (dig(next)) {
-      this.c.p += 1;
-      this.c.integer();
-      this.push(T_DOT_LITERAL, start);
+      this.p += 1;
+      this.integer();
+      this.push(DN, start);
     } else if (lo(next)) {
-      let tag = T_DOT_LOWER;
-      this.c.p += 1;
-      if (!this.c.ident()) {
-        tag = T_DOT_ERROR;
+      let tag = DL;
+      this.p += 1;
+      if (!this.ident()) {
+        tag = DER;
       }
       this.push(tag, start);
     } else if (up(next)) {
-      let tag = T_DOT_UPPER;
-      this.c.p += 1;
-      if (!this.c.ident()) {
-        tag = T_DOT_ERROR;
+      let tag = DU;
+      this.p += 1;
+      if (!this.ident()) {
+        tag = DER;
       }
       this.push(tag, start);
     } else if (next >= 0x80 && next <= 0xff) {
-      this.c.p += 1;
-      this.c.ident();
-      this.push(T_DOT_ERROR, start);
+      this.p += 1;
+      this.ident();
+      this.push(DER, start);
     } else if (next === 123) {
-      this.c.p += 1;
-      this.push(T_PUNCT, start);
+      this.p += 1;
+      this.push(P, start);
     } else if (next === 42) {
-      this.c.p += 2;
-      this.push(T_DOT_OP, start);
+      this.p += 2;
+      this.push(DO, start);
     } else {
-      this.c.p += 1;
-      this.push(T_PUNCT, start);
+      this.p += 1;
+      this.push(P, start);
     }
   }
 
   minus(start, sp) {
-    const next = this.c.at(1);
+    const next = this.at(1);
     if (next == null) {
-      this.c.p += 1;
-      this.push(T_OP, start);
+      this.p += 1;
+      this.push(O, start);
     } else if (next === 62) {
-      this.c.p += 2;
-      this.push(T_OP, start);
+      this.p += 2;
+      this.push(O, start);
     } else if (next === 32 || next === 9 || next === 10 || next === 13 || next === 35) {
-      this.c.p += 1;
-      this.push(T_OP, start);
+      this.p += 1;
+      this.push(O, start);
     } else if (dig(next)) {
       const prev = this.last();
-      if (!sp && prev != null && (prev & F_EXPR_END) !== 0) {
-        this.c.p += 1;
-        this.push(T_OP, start);
+      if (!sp && prev != null && (prev & X) !== 0) {
+        this.p += 1;
+        this.push(O, start);
       } else {
-        this.c.p += 1;
-        const tag = this.c.number();
+        this.p += 1;
+        const tag = this.number();
         this.push(tag, start);
       }
     } else {
-      this.c.p += 1;
-      this.push(T_OP, start);
+      this.p += 1;
+      this.push(O, start);
     }
   }
 
   under(start) {
-    const next = this.c.at(1);
+    const next = this.at(1);
     if (next != null && (lo(next) || up(next) || dig(next))) {
-      let tag = T_LOWER;
-      this.c.p += 2;
-      if (!this.c.ident()) {
-        tag = T_ERROR_END;
+      let tag = L;
+      this.p += 2;
+      if (!this.ident()) {
+        tag = EE;
       }
       this.push(tag, start);
     } else {
-      this.c.p += 1;
-      this.push(T_NONE, start);
+      this.p += 1;
+      this.push(Z, start);
     }
   }
 
   opaque(start) {
-    let tok = T_UPPER;
-    const next = this.c.at(1);
+    let tok = U;
+    const next = this.at(1);
     if (
       next != null &&
       (lo(next) || up(next) || dig(next) || next === 95 || next >= 0x80)
     ) {
-      this.c.p += 1;
-      if (!this.c.ident()) {
-        tok = T_ERROR_END;
+      this.p += 1;
+      if (!this.ident()) {
+        tok = EE;
       }
     } else {
-      tok = T_ERROR;
-      this.c.p += 1;
+      tok = ER;
+      this.p += 1;
     }
     this.push(tok, start);
   }
 
   dollar(start) {
-    const next = this.c.at(1);
+    const next = this.at(1);
     if (next != null && lo(next)) {
-      let tag = T_LOWER;
-      this.c.p += 1;
-      if (!this.c.ident()) {
-        tag = T_ERROR_END;
+      let tag = L;
+      this.p += 1;
+      if (!this.ident()) {
+        tag = EE;
       }
       this.push(tag, start);
     } else if (next != null && up(next)) {
-      let tag = T_UPPER;
-      this.c.p += 1;
-      if (!this.c.ident()) {
-        tag = T_ERROR_END;
+      let tag = U;
+      this.p += 1;
+      if (!this.ident()) {
+        tag = EE;
       }
       this.push(tag, start);
     } else {
-      this.c.p += 1;
-      this.push(T_ERROR, start);
+      this.p += 1;
+      this.push(ER, start);
     }
   }
 
   string() {
-    const start = this.c.p;
-    this.c.p += 1;
+    const start = this.p;
+    this.p += 1;
     let kind = "single_line";
-    if (this.c.pk() === 34 && this.c.at(1) === 34) {
-      this.c.p += 2;
+    if (this.pk() === 34 && this.at(1) === 34) {
+      this.p += 2;
       kind = "multi_line";
-      this.push(T_STRING, start);
+      this.push(S, start);
     } else {
-      this.push(T_STRING, start);
+      this.push(S, start);
     }
     this.stringBody(kind);
   }
 
   multiline() {
-    const start = this.c.p;
-    this.c.p += 2;
-    this.push(T_STRING, start);
+    const start = this.p;
+    this.p += 2;
+    this.push(S, start);
     this.stringBody("multi_line");
   }
 
   stringBody(kind) {
-    const start = this.c.p;
-    let stringPartTag = T_STRING;
-    while (this.c.p < this.c.b.length) {
-      const c = this.c.b[this.c.p];
-      if (c === 36 && this.c.at(1) === 123) {
+    const start = this.p;
+    let stringPartTag = S;
+    while (this.p < this.b.length) {
+      const c = this.b[this.p];
+      if (c === 36 && this.at(1) === 123) {
         this.push(stringPartTag, start);
-        const dollarStart = this.c.p;
-        this.c.p += 2;
-        this.push(T_KEYWORD, dollarStart);
+        const dollarStart = this.p;
+        this.p += 2;
+        this.push(K, dollarStart);
         this.s.push(kind);
         return;
       } else if (c === 10) {
         this.push(stringPartTag, start);
         if (kind === "single_line") {
-          this.push(T_STRING_END, this.c.p);
+          this.push(SE, this.p);
         }
         return;
       } else if (kind === "single_line" && c === 34) {
         this.push(stringPartTag, start);
-        const stringPartEnd = this.c.p;
-        this.c.p += 1;
-        this.push(T_STRING_END, stringPartEnd);
+        const stringPartEnd = this.p;
+        this.p += 1;
+        this.push(SE, stringPartEnd);
         return;
       } else {
-        this.c.utf8();
-        if (c === 92 && this.c.escape(34) !== true) {
-          stringPartTag = T_ERROR;
+        this.utf8();
+        if (c === 92 && this.escape(34) !== true) {
+          stringPartTag = ER;
         }
       }
     }
@@ -1002,35 +951,12 @@ class RocTokenizer {
   }
 }
 
-function rocTokens(source) {
-  return new RocTokenizer(source).tokenize();
-}
-
-function tokenClass(tag) {
-  return TOK_CLASS[tag & C_MASK];
-}
-
-function addToken(ranges, token) {
-  const cls = tokenClass(token.t);
-  if (cls == null) {
-    return;
-  }
-
-  if ((token.t & F_DOT_PREFIX) !== 0 && token.s + 1 < token.e) {
-    ranges.push({ s: token.s, e: token.s + 1, c: "p" });
-    ranges.push({ s: token.s + 1, e: token.e, c: cls });
-  } else if ((token.t & F_DOTDOT_PREFIX) !== 0 && token.s + 2 < token.e) {
-    ranges.push({ s: token.s, e: token.s + 2, c: "p" });
-    ranges.push({ s: token.s + 2, e: token.e, c: cls });
-  } else {
-    ranges.push({ s: token.s, e: token.e, c: cls });
-  }
-}
-
 function highlightRoc(source) {
-  const tokenized = rocTokens(source);
-  const ranges = [...tokenized.c];
-  const tokens = tokenized.t.filter((token) => token.s !== token.e);
+  const tokenized = new RocTokenizer(source).tokenize();
+  const tokens = tokenized.t.filter(
+    (token) => token[0] !== CM && token[1] !== token[2],
+  );
+  const fields = new Map();
 
   for (let i = 0; i < tokens.length; i += 1) {
     const previous = tokens[i - 1];
@@ -1039,31 +965,53 @@ function highlightRoc(source) {
     if (
       previous != null &&
       next != null &&
-      (previous.t & F_FIELD_PREFIX) !== 0 &&
-      (token.t & F_FIELD_NAME) !== 0 &&
-      (next.t & F_COLON) !== 0 &&
-      decode(tokenized.b.subarray(token.e, next.s)).trim() === ""
+      (previous[0] & A) !== 0 &&
+      (token[0] & N) !== 0 &&
+      (next[0] & H) !== 0 &&
+      decode(tokenized.b.subarray(token[2], next[1])).trim() === ""
     ) {
-      ranges.push({ s: token.s, e: next.e, c: "f" });
-      i += 1;
-    } else {
-      addToken(ranges, token);
+      fields.set(token[1], next[2]);
     }
   }
 
-  ranges.sort((a, b) => a.s - b.s || a.e - b.e);
-
   let html = "";
   let lastEnd = 0;
-  for (const range of ranges) {
-    if (range.s < lastEnd) {
+
+  const emit = (start, end, cls) => {
+    html += htmlEscape(decode(tokenized.b.subarray(lastEnd, start)));
+    html += `<span class="${cls}">`;
+    html += htmlEscape(decode(tokenized.b.subarray(start, end)));
+    html += "</span>";
+    lastEnd = end;
+  };
+
+  for (const token of tokenized.t) {
+    const tag = token[0];
+    let start = token[1];
+    let end = token[2];
+    if (start === end || start < lastEnd) {
       continue;
     }
-    html += htmlEscape(decode(tokenized.b.subarray(lastEnd, range.s)));
-    html += `<span class="${range.c}">`;
-    html += htmlEscape(decode(tokenized.b.subarray(range.s, range.e)));
-    html += "</span>";
-    lastEnd = range.e;
+
+    const fieldEnd = fields.get(start);
+    let cls = fieldEnd == null ? CL[tag & M] : "f";
+    if (cls == null) {
+      continue;
+    }
+
+    if (fieldEnd != null) {
+      end = fieldEnd;
+    }
+
+    if (fieldEnd == null && (tag & B) !== 0 && start + 1 < end) {
+      emit(start, start + 1, "p");
+      emit(start + 1, end, cls);
+    } else if (fieldEnd == null && (tag & G) !== 0 && start + 2 < end) {
+      emit(start, start + 2, "p");
+      emit(start + 2, end, cls);
+    } else {
+      emit(start, end, cls);
+    }
   }
   html += htmlEscape(decode(tokenized.b.subarray(lastEnd)));
   return html || " ";

--- a/website/public/site.css
+++ b/website/public/site.css
@@ -1797,7 +1797,7 @@ code .dim,
 }
 
 .roc-interactive .roc-output pre.roc-terminal {
-    line-height: 1;
+    line-height: 1.175;
     white-space: pre;
 }
 

--- a/website/public/site.css
+++ b/website/public/site.css
@@ -924,7 +924,8 @@ details {
 
 /* Comments `#` and Documentation comments `##` */
 samp .comment,
-code .comment {
+code .comment,
+.roc-source-highlight .comment {
     color: #ccc;
 }
 
@@ -939,6 +940,8 @@ samp .string.end,
 code .string.end,
 samp .constant,
 code .constant,
+.roc-source-highlight .literal,
+.roc-source-highlight .string,
 samp .literal,
 code .literal {
     color: var(--dark-cyan);
@@ -954,7 +957,8 @@ code .punctuation.separator,
 samp .punctuation.terminator,
 code .punctuation.terminator,
 samp .kw,
-code .kw {
+code .kw,
+.roc-source-highlight .keyword {
     color: var(--primary-1);
 }
 
@@ -964,14 +968,21 @@ code .op,
 samp .keyword.operator,
 code .keyword.operator,
 samp .colon,
-code .colon {
+code .colon,
+.roc-source-highlight .op {
     color: var(--primary-1);
 }
 
 /* Delimieters */
 samp .delimiter,
-code .delimiter {
+code .delimiter,
+.roc-source-highlight .delimiter {
     color: var(--primary-1);
+}
+
+.roc-source-highlight .field,
+.roc-source-highlight .punctuation {
+    color: #aeb4c6;
 }
 
 /* Variables modules and field names */
@@ -982,12 +993,14 @@ code .meta.group,
 samp .meta.block,
 code .meta.block,
 samp .lowerident,
-code .lowerident {
+code .lowerident,
+.roc-source-highlight .lowerident {
     color: white;
 }
 
 samp .error,
-code .error {
+code .error,
+.roc-source-highlight .error {
     color: hsl(0, 96%, 67%);
 }
 
@@ -997,7 +1010,8 @@ code .type,
 samp .meta.path,
 code .meta.path,
 samp .upperident,
-code .upperident {
+code .upperident,
+.roc-source-highlight .upperident {
     color: var(--dark-cyan);
 }
 
@@ -1654,22 +1668,49 @@ code .dim {
     max-width: 720px;
 }
 
-.roc-interactive textarea.roc-source {
+.roc-interactive .roc-source-editor {
+    position: relative;
+}
+
+.roc-interactive textarea.roc-source,
+.roc-interactive .roc-source-highlight {
     display: block;
     width: 100%;
     box-sizing: border-box;
-    border: none;
+    min-height: 100%;
+    margin: 0;
     padding: 0.75em;
     font-family: monospace;
     font-size: var(--font-size-normal);
+    line-height: normal;
     tab-size: 4;
-    resize: vertical;
-    background: var(--dark-code-bg);
-    color: #e0d6f0;
     border: 1px solid #ddd;
     white-space: pre;
     overflow-wrap: normal;
     overflow-x: auto;
+}
+
+.roc-interactive textarea.roc-source {
+    position: relative;
+    z-index: 1;
+    resize: vertical;
+    background: transparent;
+    color: transparent;
+    caret-color: #e0d6f0;
+}
+
+.roc-interactive textarea.roc-source::selection {
+    color: transparent;
+}
+
+.roc-interactive .roc-source-highlight {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    overflow: hidden;
+    background: var(--dark-code-bg);
+    color: #e0d6f0;
 }
 
 /* Shown only when JS is disabled — the script replaces it with the textarea above. */

--- a/website/public/site.css
+++ b/website/public/site.css
@@ -925,6 +925,8 @@ details {
 /* Comments `#` and Documentation comments `##` */
 samp .comment,
 code .comment,
+.roc-interactive .ansi-fg-black,
+.roc-interactive .ansi-fg-bright-black,
 .roc-source-highlight .comment {
     color: #ccc;
 }
@@ -942,6 +944,10 @@ samp .constant,
 code .constant,
 .roc-source-highlight .literal,
 .roc-source-highlight .string,
+.roc-interactive .ansi-fg-green,
+.roc-interactive .ansi-fg-bright-green,
+.roc-interactive .ansi-fg-cyan,
+.roc-interactive .ansi-fg-bright-cyan,
 samp .literal,
 code .literal {
     color: var(--dark-cyan);
@@ -958,6 +964,12 @@ samp .punctuation.terminator,
 code .punctuation.terminator,
 samp .kw,
 code .kw,
+.roc-interactive .ansi-fg-blue,
+.roc-interactive .ansi-fg-bright-blue,
+.roc-interactive .ansi-fg-magenta,
+.roc-interactive .ansi-fg-bright-magenta,
+.roc-interactive .ansi-fg-yellow,
+.roc-interactive .ansi-fg-bright-yellow,
 .roc-source-highlight .keyword {
     color: var(--primary-1);
 }
@@ -994,12 +1006,17 @@ samp .meta.block,
 code .meta.block,
 samp .lowerident,
 code .lowerident,
+.roc-interactive .ansi-fg-white,
+.roc-interactive .ansi-fg-bright-white,
+.roc-interactive .roc-output pre.roc-terminal,
 .roc-source-highlight .lowerident {
     color: white;
 }
 
 samp .error,
 code .error,
+.roc-interactive .ansi-fg-red,
+.roc-interactive .ansi-fg-bright-red,
 .roc-source-highlight .error {
     color: hsl(0, 96%, 67%);
 }
@@ -1016,7 +1033,8 @@ code .upperident,
 }
 
 samp .dim,
-code .dim {
+code .dim,
+.roc-interactive .ansi-dim {
     opacity: 0.55;
 }
 
@@ -1700,6 +1718,7 @@ code .dim {
 }
 
 .roc-interactive textarea.roc-source::selection {
+    background: color-mix(in srgb, var(--primary-2) 45%, transparent);
     color: transparent;
 }
 
@@ -1766,12 +1785,32 @@ code .dim {
     color: var(--text-color);
 }
 
-.roc-interactive .roc-output pre {
+.roc-interactive .roc-output pre,
+.roc-interactive .roc-output pre.roc-terminal {
     padding: 0.75em;
     background-color: #151517;
     margin: 0;
     font: inherit;
+    line-height: 1.35;
     white-space: pre-wrap;
+    overflow-x: auto;
+}
+
+.roc-interactive .roc-output pre.roc-terminal {
+    line-height: 1;
+    white-space: pre;
+}
+
+.roc-interactive .ansi-bold {
+    font-weight: 700;
+}
+
+.roc-interactive .ansi-italic {
+    font-style: italic;
+}
+
+.roc-interactive .ansi-underline {
+    text-decoration: underline;
 }
 
 /* Right-align the Run button so it falls under the thumb on mobile. Defined
@@ -1784,7 +1823,7 @@ code .dim {
     }
 }
 
-/* ---- compiler diagnostics (emitted as HTML by js_stderr) ---- */
+/* ---- legacy compiler diagnostics ---- */
 
 .report {
     border-left: 3px solid #555;

--- a/website/public/site.css
+++ b/website/public/site.css
@@ -925,9 +925,8 @@ details {
 /* Comments `#` and Documentation comments `##` */
 samp .comment,
 code .comment,
-.roc-interactive .ansi-fg-black,
-.roc-interactive .ansi-fg-bright-black,
-.roc-source-highlight .comment {
+.roc-interactive .roc-output .c,
+.roc-source-highlight .c {
     color: #ccc;
 }
 
@@ -942,12 +941,9 @@ samp .string.end,
 code .string.end,
 samp .constant,
 code .constant,
-.roc-source-highlight .literal,
-.roc-source-highlight .string,
-.roc-interactive .ansi-fg-green,
-.roc-interactive .ansi-fg-bright-green,
-.roc-interactive .ansi-fg-cyan,
-.roc-interactive .ansi-fg-bright-cyan,
+.roc-source-highlight .n,
+.roc-source-highlight .s,
+.roc-interactive .roc-output .n,
 samp .literal,
 code .literal {
     color: var(--dark-cyan);
@@ -964,13 +960,8 @@ samp .punctuation.terminator,
 code .punctuation.terminator,
 samp .kw,
 code .kw,
-.roc-interactive .ansi-fg-blue,
-.roc-interactive .ansi-fg-bright-blue,
-.roc-interactive .ansi-fg-magenta,
-.roc-interactive .ansi-fg-bright-magenta,
-.roc-interactive .ansi-fg-yellow,
-.roc-interactive .ansi-fg-bright-yellow,
-.roc-source-highlight .keyword {
+.roc-interactive .roc-output .k,
+.roc-source-highlight .k {
     color: var(--primary-1);
 }
 
@@ -981,19 +972,19 @@ samp .keyword.operator,
 code .keyword.operator,
 samp .colon,
 code .colon,
-.roc-source-highlight .op {
+.roc-source-highlight .o {
     color: var(--primary-1);
 }
 
 /* Delimieters */
 samp .delimiter,
 code .delimiter,
-.roc-source-highlight .delimiter {
+.roc-source-highlight .d {
     color: var(--primary-1);
 }
 
-.roc-source-highlight .field,
-.roc-source-highlight .punctuation {
+.roc-source-highlight .f,
+.roc-source-highlight .p {
     color: #aeb4c6;
 }
 
@@ -1006,18 +997,16 @@ samp .meta.block,
 code .meta.block,
 samp .lowerident,
 code .lowerident,
-.roc-interactive .ansi-fg-white,
-.roc-interactive .ansi-fg-bright-white,
+.roc-interactive .roc-output .v,
 .roc-interactive .roc-output pre.roc-terminal,
-.roc-source-highlight .lowerident {
+.roc-source-highlight .v {
     color: white;
 }
 
 samp .error,
 code .error,
-.roc-interactive .ansi-fg-red,
-.roc-interactive .ansi-fg-bright-red,
-.roc-source-highlight .error {
+.roc-interactive .roc-output .e,
+.roc-source-highlight .e {
     color: hsl(0, 96%, 67%);
 }
 
@@ -1028,13 +1017,13 @@ samp .meta.path,
 code .meta.path,
 samp .upperident,
 code .upperident,
-.roc-source-highlight .upperident {
+.roc-source-highlight .u {
     color: var(--dark-cyan);
 }
 
 samp .dim,
 code .dim,
-.roc-interactive .ansi-dim {
+.roc-interactive .roc-output .m {
     opacity: 0.55;
 }
 
@@ -1801,15 +1790,15 @@ code .dim,
     white-space: pre;
 }
 
-.roc-interactive .ansi-bold {
+.roc-interactive .roc-output .b {
     font-weight: 700;
 }
 
-.roc-interactive .ansi-italic {
+.roc-interactive .roc-output .i {
     font-style: italic;
 }
 
-.roc-interactive .ansi-underline {
+.roc-interactive .roc-output .x {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
Adds inline Roc syntax highlighting to the homepage interactive example without introducing another JavaScript file. Compiler output is now rendered as escaped terminal text with ANSI styling so diagnostics from echo.wasm preserve their box art and share the existing site color selectors, with terminal spacing tuned for the homepage widget.