### PR TITLE
Minify website assets during deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Build with:
 ```sh
 cd website
 roc ./build_website.roc
+# For a production build, minify copied assets too. This requires
+# github.com/tdewolff/minify/v2/cmd/minify on PATH.
+roc ./build_website.roc --minify
 # If you want a local deploy for development, do:
 npx http-server ./build -c-1 -p 8080
 ```

--- a/build_cloudflare.sh
+++ b/build_cloudflare.sh
@@ -22,7 +22,11 @@ mv roc_nightly* roc_nightly
 # make roc command available
 export PATH=$PATH:$(pwd)/roc_nightly
 
+# Install the no-npm asset minifier used by the production build.
+go install github.com/tdewolff/minify/v2/cmd/minify@v2.24.13
+export PATH=$PATH:$(go env GOPATH)/bin
+
 cd website
 roc check build_website.roc
 roc build build_website.roc
-./build_website
+./build_website --minify

--- a/build_cloudflare.sh
+++ b/build_cloudflare.sh
@@ -23,8 +23,14 @@ mv roc_nightly* roc_nightly
 export PATH=$PATH:$(pwd)/roc_nightly
 
 # Install the no-npm asset minifier used by the production build.
+# GOBIN is set explicitly because installing this package can trigger Go's
+# automatic toolchain switch (it requires a newer Go than what's active),
+# and `go env GOPATH` queried afterwards can then resolve to a different
+# directory than the one the switched toolchain actually installed into.
+export GOBIN="$(pwd)/gobin"
+mkdir -p "$GOBIN"
 go install github.com/tdewolff/minify/v2/cmd/minify@v2.24.13
-export PATH=$PATH:$(go env GOPATH)/bin
+export PATH=$PATH:$GOBIN
 
 cd website
 roc check build_website.roc

--- a/website/build_website.roc
+++ b/website/build_website.roc
@@ -13,6 +13,7 @@ import cli.Utc
 # Usage:
 #   roc ./build_website.roc           # full, clean build (no cache)
 #   roc ./build_website.roc --cache   # incremental build using cache
+#   roc ./build_website.roc --minify  # minify build assets after building
 
 latest_stable_tag = "alpha4-rolling"
 cache_marker_path = ".cache/site.millis"
@@ -22,6 +23,7 @@ main! : List Arg => Result {} _
 main! = |raw_args|
     args = List.map(raw_args, Arg.display)
     use_cache = List.any(args, |a| a == "--cache")
+    use_minify = List.any(args, |a| a == "--minify")
 
     cwd_path = Env.cwd!({}) ? EncCwdFailed
     cwd_path_str = Path.display(cwd_path)
@@ -38,7 +40,30 @@ main! = |raw_args|
     else
         full_clean_build!({})?
 
+    if use_minify then
+        minify_build_assets!({})?
+    else
+        {}
+
     Stdout.line!("Website built in dir 'website/build'.")
+
+minify_build_assets! : {} => Result {} _
+minify_build_assets! = |{}|
+    minify_build_asset!("build/compiler.js")?
+    minify_build_asset!("build/site.js")?
+    minify_build_asset!("build/site.css")?
+
+    Ok({})
+
+minify_build_asset! : Str => Result {} _
+minify_build_asset! = |path|
+    tmp_path = "${path}.min"
+
+    _ = File.delete!(tmp_path)
+    Cmd.exec!("minify", ["-o", tmp_path, path])?
+    Cmd.exec!("mv", [tmp_path, path])?
+
+    Ok({})
 
 # ----------------
 # Full clean build


### PR DESCRIPTION
This adds an opt-in minification step to the website build and uses it from the Cloudflare deploy script. The deploy path installs the pinned Go-based tdewolff/minify CLI, avoiding npm entirely, then rewrites the copied build assets for compiler.js, site.js, and site.css after the site is generated.