### PR TITLE
Run wasm optimization to convergence

### DIFF
--- a/website/build_website.roc
+++ b/website/build_website.roc
@@ -262,6 +262,7 @@ optimize_compiler_wasm! = |{}|
         "--enable-bulk-memory",
         "--enable-nontrapping-float-to-int",
         "-Oz",
+        "--converge",
         compiler_wasm_build_path,
         "-o",
         compiler_wasm_optimized_path,


### PR DESCRIPTION
Run Binaryen's size-focused optimization pipeline repeatedly while each iteration continues shrinking the generated compiler WebAssembly. This trades additional website build time for the smallest result Binaryen can produce with the existing safe optimization settings.