### PR TITLE
Use full Source Code Pro for interactive diagnostics

### DIFF
--- a/website/build_website.roc
+++ b/website/build_website.roc
@@ -26,6 +26,11 @@ binaryen_dir = ".cache/binaryen-version_130"
 binaryen_archive_path = ".cache/binaryen-version_130-node.tar.gz"
 binaryen_wasm_opt_path = ".cache/binaryen-version_130/wasm-opt.js"
 binaryen_wasm_opt_module_path = ".cache/binaryen-version_130/wasm-opt.wasm"
+# Keep the complete font because interactive editors accept arbitrary source text,
+# and compiler diagnostics use Unicode box-drawing glyphs.
+source_code_pro_commit = "803b7e23ec97ae58b6232ea76519a76d428ba268"
+source_code_pro_font_path = "build/fonts/source-code-pro/SourceCodePro-Regular.ttf.woff2"
+source_code_pro_font_url = "https://raw.githubusercontent.com/adobe-fonts/source-code-pro/${source_code_pro_commit}/WOFF2/TTF/SourceCodePro-Regular.ttf.woff2"
 
 main! : List Arg => Result {} _
 main! = |raw_args|
@@ -112,16 +117,8 @@ full_clean_build! = |{}|
     Dir.delete_all!("examples-main") ? DeleteExamplesMainDirFailed
     File.delete!("examples-main.zip") ? DeleteExamplesMainZipFailed
 
-    # download fonts just-in-time so we don't have to bloat the repo with them.
-    design_assets_commit = "4d949642ebc56ca455cf270b288382788bce5873"
-    design_assets_tarfile = "roc-lang-design-assets-4d94964.tar.gz"
-    design_assets_dir = "roc-lang-design-assets-4d94964"
-
-    Cmd.exec!("curl", ["-fLJO", "https://github.com/roc-lang/design-assets/tarball/${design_assets_commit}"])?
-    Cmd.exec!("tar", ["-xzf", design_assets_tarfile])?
-    Cmd.exec!("mv", ["${design_assets_dir}/fonts", "build/fonts"])?
-    Dir.delete_all!(design_assets_dir) ? DeleteDesignAssetsDirFailed
-    File.delete!(design_assets_tarfile) ? DeleteDesignAssetsTarFailed
+    # Download fonts just-in-time so we don't have to bloat the repo with them.
+    ensure_fonts_present!({})?
 
     repl_tarfile = "roc_repl_wasm.tar.gz"
     _ = File.delete!(repl_tarfile)
@@ -297,7 +294,7 @@ ensure_fonts_present! : {} => Result {} _
 ensure_fonts_present! = |{}|
     fonts_dir_exists = File.is_dir!("build/fonts") |> Result.with_default(Bool.false)
     if fonts_dir_exists then
-        Ok({})
+        {}
     else
         design_assets_commit = "4d949642ebc56ca455cf270b288382788bce5873"
         design_assets_tarfile = "roc-lang-design-assets-4d94964.tar.gz"
@@ -308,6 +305,19 @@ ensure_fonts_present! = |{}|
         Cmd.exec!("mv", ["${design_assets_dir}/fonts", "build/fonts"])?
         _ = Dir.delete_all!(design_assets_dir)
         _ = File.delete!(design_assets_tarfile)
+        {}
+
+    full_source_code_pro_exists = File.exists!(source_code_pro_font_path)?
+    if full_source_code_pro_exists then
+        Ok({})
+    else
+        source_code_pro_font_tmp_path = "${source_code_pro_font_path}.download"
+
+        Dir.create_all!("build/fonts/source-code-pro")?
+        _ = File.delete!(source_code_pro_font_tmp_path)
+        Cmd.exec!("curl", ["-fL", "-o", source_code_pro_font_tmp_path, source_code_pro_font_url])?
+        File.rename!(source_code_pro_font_tmp_path, source_code_pro_font_path)?
+
         Ok({})
 
 ensure_repl_present! : {} => Result {} _

--- a/website/public/site.css
+++ b/website/public/site.css
@@ -803,35 +803,12 @@ details {
         U+2215, U+FEFF, U+FFFD;
 }
 
-/* latin-ext */
 @font-face {
     font-family: "Source Code Pro";
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src:
-        url("/fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/source-code-pro-v22-latin-ext_latin/source-code-pro-v22-latin-ext_latin-regular.woff")
-            format("woff");
-    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-        U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-/* latin */
-@font-face {
-    font-family: "Source Code Pro";
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    src:
-        url("/fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff2")
-            format("woff2"),
-        url("/fonts/source-code-pro-v22-latin/source-code-pro-v22-latin-regular.woff")
-            format("woff");
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-        U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212,
-        U+2215, U+FEFF, U+FFFD;
+    src: url("/fonts/source-code-pro/SourceCodePro-Regular.ttf.woff2") format("woff2");
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1711,7 +1688,7 @@ code .dim,
     min-height: 100%;
     margin: 0;
     padding: 0.75em;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: var(--font-size-normal);
     line-height: normal;
     tab-size: 4;
@@ -1757,7 +1734,7 @@ code .dim,
     box-sizing: border-box;
     margin: 0;
     padding: 0.75em;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: var(--font-size-normal);
     tab-size: 4;
     background: var(--dark-code-bg);
@@ -1790,7 +1767,7 @@ code .dim,
 
 .roc-interactive .roc-output {
     color: #b794e0;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: var(--font-size-normal);
     white-space: pre-wrap;
     min-height: 1.2em;
@@ -1871,7 +1848,7 @@ code .dim,
 
 .report pre {
     margin: 0.2em 0;
-    font-family: monospace;
+    font-family: var(--font-mono);
     font-size: 12px;
     white-space: pre-wrap;
 }


### PR DESCRIPTION
Use Adobe’s complete Source Code Pro webfont instead of the Latin-only subsets so user-entered source and compiler box-drawing diagnostics render with consistent character metrics. The font is fetched atomically from a pinned upstream commit during website builds, and interactive editors and output now use the same monospace stack as the rest of the site.