### PR TITLE
Update to new compiler

### DIFF
--- a/website/content/faq.md
+++ b/website/content/faq.md
@@ -32,21 +32,26 @@ Fun fact: "roc" translates to 鹏 in Chinese, [which means](https://www.mdbg.net
 
 ## [Why does Roc not handle strings like most languages?](#strings-in-roc) {#strings-in-roc}
 
-We want to help you make reliable software, so we aim to make sure that you're aware of all the pitfalls when handing strings.
-For (professional) software that needs to be reliable, check out the explainer [here](https://www.roc-lang.org/docs/main/Str) and the [unicode package](https://github.com/roc-lang/unicode) (still on Roc alpha 4).
-For personal scripts or things like advent of code, the [roc-ascii package](https://github.com/Hasnep/roc-ascii) (still on Roc alpha 4) can cover your needs.
+We want to help you make reliable software, so we aim to make sure that you're aware of all the pitfalls when handling
+strings. In many cases, the functions available in the built-in [`Str`](https://www.roc-lang.org/docs/main/Str) type are
+sufficient (it has `concat`, `contains`, `starts_with` and many more functions). You can also use `Str.to_utf8` to
+convert a `Str` to a `List(U8)`, perform some operations, then convert back to `Str` using `Str.from_utf8`. However,
+Unicode is a complex and evolving topic, so it is usually best handled by a dedicated library, such as
+[roc-lang/unicode](https://github.com/roc-lang/unicode): check it out! For pure ASCII text, you may prefer to use a
+dedicated library such as [Hasnep/roc-ascii](https://github.com/Hasnep/roc-ascii) (currently being ported to the new
+Roc syntax).
 
+## [Why can't `exposing` import everything?](#import-everything) {#import-everything}
 
-## [Why is there no way to specify "import everything this module exposes" in `imports`?](#import-everything) {#import-everything}
+Roc can bring specific public definitions into scope with an import such as `import Http exposing [Request, Response]`.
+You can also import the type itself using `import Http`, then use `Http.Request` and `Http.Response`.
+There is intentionally no wildcard form that brings every public definition into scope. Some languages provide one
+because it can be convenient, but it also has downsides.
 
-In [Elm](https://elm-lang.org), it's possible to import a module in a way that brings everything that module
-exposes into scope. It can be convenient, but like all programming language features, it has downsides.
-
-A minor reason Roc doesn't have this feature is that exposing everything can make it more difficult
-outside the editor (e.g. on a website) to tell where something comes from, especially if multiple imports are
-using this. ("I don't see `blah` defined in this module, so it must be coming from an import...but which of
-these several import-exposing-everything modules could it be? I'll have to check all of them, or
-download this code base and open it up in the editor so I can jump to definition!")
+A minor reason Roc doesn't have wildcard imports is that they can make it more difficult outside the editor (e.g. on a
+website) to tell where something comes from, especially if multiple imports are using them. ("I don't see `blah` defined
+in this file, so it must be coming from an import...but which of these several wildcard imports could it be? I'll have
+to check all of them, or download this code base and open it up in the editor so I can jump to definition!")
 
 The main reason for this design, though, is compiler performance.
 
@@ -56,10 +61,9 @@ allowed, then it's no longer clear whether anything is a naming error or not, un
 modules have been processed, so we know exactly which names they expose. Because that feature doesn't exist in Roc,
 all modules can do name resolution in parallel.
 
-Of note, allowing this feature would only slow down modules that used it; modules that didn't use it would still be
-parallelizable. However, when people find out ways to speed up their builds (in any language), advice starts to
-circulate about how to unlock those speed boosts. If Roc had this feature, it's predictable that a commonly-accepted
-piece of advice would eventually circulate: "don't use this feature because it slows down your builds."
+Allowing wildcard imports would only impose that cost on files that used them. However, when people discover ways
+to speed up builds, advice starts to circulate about avoiding slower features. If Roc had wildcard imports, a
+predictable recommendation would eventually be: "don't use this feature because it slows down your builds."
 
 If a feature exists in a language, but the common recommendation is never to use it, that's cause for reconsidering
 whether the feature should be in the language at all. In the case of this feature, it's simpler if the
@@ -82,7 +86,7 @@ By design, Roc does not have one of these. There are several reasons for this.
 First, if a function returns a potential error, Roc has the convention to use `Try` with an error type that
 has a single tag describing what went wrong. (For example, `List.first : List(item) -> Try(item, [ListWasEmpty, ..])`
 instead of `List.first : List(item) -> Maybe(item)`.) This is not only more self-descriptive, it also composes better with
-other operations that can fail; there's no need to have functions like `Try.toMaybe` or `Maybe.toTry`,
+other operations that can fail; there's no need to have functions like `Try.to_maybe` or `Maybe.to_try`,
 because in Roc, the convention is that operations that can fail always use `Try`.
 
 To describe something that's not an operation that can fail, an explicit tag union can be
@@ -249,27 +253,27 @@ a new function by composing together two existing functions without naming inter
 Here's an example:
 
 ```roc
-reverse_sort : List(elem) -> List(elem)
-reverse_sort = compose(List.reverse, List.sort)
+normalize : Str -> Str
+normalize = compose(Str.trim, Str.with_ascii_lowercased)
 
 compose : (a -> b), (c -> a) -> (c -> b)
-compose = |f, g, x| -> f(g(x))
+compose = |f, g| |x| f(g(x))
 ```
 
 Here's a way to write it without pointfree function composition:
 
 ```roc
-reverse_sort : List(elem) -> List(elem)
-reverse_sort = |list| list.sort().reverse()
+normalize : Str -> Str
+normalize = |str| str.with_ascii_lowercased().trim()
 ```
 
-It's common for programmers to build a mental model of what `compose(List.reverse, List.sort)` does by mentally
-translating it into `|list| list.sort().reverse()`. This extra mental translation step makes it take
+It's common for programmers to build a mental model of what `compose(Str.trim, Str.with_ascii_lowercased)` does by mentally
+translating it into `|str| str.with_ascii_lowercased().trim()`. This extra mental translation step makes it take
 longer to read and to understand despite being technically more concise. In more complex examples (this
 is among the tamest of pointfree function composition examples), the chances increase of making a mistake in
 the mental translation step, leading to a misunderstanding of what the function is doing—which can cause bugs.
 
-Some languages place such a high value on conciseness that they would consider the conciceness upside to outweigh
+Some languages place such a high value on conciseness that they would consider the conciseness upside to outweigh
 these downsides, but Roc is not one of those languages. It's considered stylistically better in Roc to write the
 second version above. Given this, since currying facilitates pointfree function composition, making Roc a curried
 language would have the downside of facilitating an antipattern in the language.

--- a/website/content/faq.md
+++ b/website/content/faq.md
@@ -38,8 +38,7 @@ sufficient (it has `concat`, `contains`, `starts_with` and many more functions).
 convert a `Str` to a `List(U8)`, perform some operations, then convert back to `Str` using `Str.from_utf8`. However,
 Unicode is a complex and evolving topic, so it is usually best handled by a dedicated library, such as
 [roc-lang/unicode](https://github.com/roc-lang/unicode): check it out! For pure ASCII text, you may prefer to use a
-dedicated library such as [Hasnep/roc-ascii](https://github.com/Hasnep/roc-ascii) (currently being ported to the new
-Roc syntax).
+dedicated library such as [Hasnep/roc-ascii](https://github.com/Hasnep/roc-ascii).
 
 ## [Why can't `exposing` import everything?](#import-everything) {#import-everything}
 

--- a/website/content/friendly.md
+++ b/website/content/friendly.md
@@ -7,9 +7,9 @@ Besides having a [friendly community](/community), Roc also prioritizes being a 
 Roc's syntax isn't trivial, but there also isn't much of it to learn. It's designed to be uncluttered and unambiguous. A goal is that you can normally look at a piece of code and quickly get an accurate mental model of what it means, without having to think through several layers of indirection. Here are some examples:
 
 - `user.email` always accesses the `email` field of a record named `user`. <span class="nowrap">(Roc has</span> no inheritance, subclassing, or proxying.)
-- `Email.isValid` always refers to something named `isValid` exported by a module named `Email`. (Module names are always capitalized, and variables/constants never are.) Modules are always defined statically and can't be modified at runtime; there's no [monkey patching](https://en.wikipedia.org/wiki/Monkey_patch) to consider either.
-- `x = doSomething(y, z)` always declares a new constant `x` to be whatever the `doSomething` function returns when passed the arguments `y` and `z`.
-- `"Name: ${name.trim()}"` uses *string interpolation* syntax: a dollar sign inside a string literal, followed by an expression in parentheses.
+- `Email.is_valid` always refers to the definition named `is_valid` associated with the `Email` type. Type names are capitalized, while definitions use lowercase snake case. Associated definitions are resolved statically and can't be modified at runtime; there's no [monkey patching](https://en.wikipedia.org/wiki/Monkey_patch) to consider either.
+- `x = do_something(y, z)` always declares a new constant `x` whose value is whatever the `do_something` function returns when passed the arguments `y` and `z`.
+- `"Name: ${name.trim()}"` uses *string interpolation* syntax: a dollar sign inside a string literal, followed by an expression in curly braces.
 
 Roc also ships with a source code formatter that helps you maintain a consistent style with little effort. The `roc fmt` command neatly formats your source code according to a common style, and it's designed with the time-saving feature of having no configuration options. This feature saves teams all the time they would otherwise spend debating which stylistic tweaks to settle on!
 
@@ -19,50 +19,44 @@ Roc's compiler is designed to help you out. It does complete type inference acro
 
 If there's a problem at compile time, the compiler is designed to report it in a helpful way. Here's an example:
 
-<pre><samp class="code-snippet"><span class="literal">── TYPE MISMATCH ─────────────────────────────────</span>
+<pre><samp class="code-snippet"><span class="literal">── ✗ type mismatch ──────────────── /.../main.roc:6:33</span>
 
-This expression is used in an unexpected way:
-   ┌─ /.../main.roc:4:9
-   │
-<span class="literal">4 │</span> <span class="error">        if some_decimal > 0</span>
-<span class="literal">5 │</span> <span class="error">            some_decimal + 1</span>
-<span class="literal">6 │</span> <span class="error">        else</span>
-<span class="literal">7 │</span> <span class="error">            0</span>
+The first branch of this if does not match the previous branch.
 
-It has the type:
+result = if args.is_empty() {
+    <span class="error">some_decimal + 1</span>
+} else {
 
-    <span class="literal">I64</span>
+The first branch is:
 
-But you are trying to use it as:
+    <span class="literal">Dec</span>
 
-    <span class="literal">Dec</span></samp></pre>
+But the previous branch results in:
 
-If you like, you can run a program that has compile-time errors like this by using the flag `--allow-errors`. If the program reaches the error at runtime, it will crash.
+    <span class="literal">I64</span></samp></pre>
 
-This lets you do things like trying out code that's only partially finished, or running tests for one part of your code base while other parts have compile errors. (Note that this feature is only partially completed, and often errors out; it has a ways to go before it works for all compile errors!)
+If you like, you can run a program that has compile-time errors like this. If the program reaches the error at runtime, it will crash.
+
+This lets you try partially finished code or run tests for one part of your code base while another part has checked errors. (Note that this feature is only partially completed, and often errors out; it has a ways to go before it works for all compile errors!)
 
 ## [Testing](#testing) {#testing}
 
-The `roc test` command runs a Roc program's tests. Each test is declared with the `expect` keyword, and can be as short as one line. For example, this is a complete test:
+The `roc test` command runs a Roc program's tests. Each test is declared with the `expect` keyword, and the expectation itself can be as short as one line. For example, this is a complete minimal program with one test:
 
 ```roc
 ## One plus one should equal two.
 expect 1 + 1 == 2
+
+main! = |_args| Ok({})  # the main! function does nothing in this case
 ```
 
-If the test fails, `roc test` will show you the line number of the `expect` that failed. <a href="https://github.com/roc-lang/roc/issues/9320">You can help improve this to make it friendlier</a>!
-
-If the test fails, `roc test` will show you the source code of the `expect`. If you write a documentation comment right before it (like `## One plus one should equal two` here), it will appear in the test output, so you can use that to add some descriptive context to the test if you want to.
-
+If the test fails, `roc test` shows its source location and source code. If you write a documentation comment right before the `expect` (like `## One plus one should equal two` here), it will appear in the test output, so you can use that to add some descriptive context to the test if you want to.
 
 ## [Inline expectations](#inline-expect) {#inline-expect}
 
-You can also use `expect` in the middle of functions. This lets you verify assumptions that can't reasonably be encoded in types, but which can be checked at runtime. Similarly to [assertions](https://en.wikipedia.org/wiki/Assertion_(software_development)) in other languages, these will run not only during normal program execution, but also during your tests—and they will fail the test if any of them fails.
+You can also use `expect` inside functions. This lets you verify assumptions that can't reasonably be encoded in types but can be checked while running tests or development builds. If an executed inline `expect` fails, the failure is reported and execution continues.
 
-Unlike assertions (and unlike the `crash` keyword), failed `expect`s do not halt the program; instead, the failure will be reported and the program will continue. 
-
-<!-- TODO uncomment once #9442 is implemented
-This means all `expect`s can be safely removed during `--optimize` builds without affecting program behavior—and so `--optimize` does remove them. This means you can add inline `expect`s without having to weigh each one's helpfulness against the performance cost of its runtime check, because they won't have any runtime cost after `--optimize` removes them.
+All `expect` statements are removed in optimized builds (using `--opt=speed`), so inline expectations will have no runtime cost. It's important to note that inline expectations are development checks, not a substitute for handling errors that can occur in production.
 
 In the future, there are plans to add built-in support for [benchmarking](https://en.wikipedia.org/wiki/Benchmark_(computing)), [generative tests](https://en.wikipedia.org/wiki/Software_testing#Property_testing), [snapshot tests](https://en.wikipedia.org/wiki/Software_testing#Output_comparison_testing), simulated I/O (so you don't have to actually run the real I/O operations, but also don't have to change your code to accommodate the tests), and "reproduction replays"—tests generated from a recording of what actually happened during a particular run of your program, which deterministically simulate all the I/O that happened.
 -->

--- a/website/content/friendly.md
+++ b/website/content/friendly.md
@@ -54,7 +54,7 @@ If the test fails, `roc test` shows its source location and source code. If you 
 
 ## [Inline expectations](#inline-expect) {#inline-expect}
 
-You can also use `expect` inside functions. This lets you verify assumptions that can't reasonably be encoded in types but can be checked while running tests or development builds. If an executed inline `expect` fails, the failure is reported and execution continues.
+You can also use `expect` inside functions. This lets you verify assumptions that can't reasonably be encoded in types but can be checked at runtime. If an executed inline `expect` fails, the failure is reported and execution continues.
 
 All `expect` statements are removed in optimized builds (using `--opt=speed`), so inline expectations will have no runtime cost. It's important to note that inline expectations are development checks, not a substitute for handling errors that can occur in production.
 

--- a/website/content/functional.md
+++ b/website/content/functional.md
@@ -1,6 +1,8 @@
 # Functional
 
-Roc is designed to have a small number of simple language primitives. This goal leads Roc to be a [functional](https://en.wikipedia.org/wiki/Functional_programming) language, while its [performance goals](/fast) lead to some design choices that are uncommon in functional languages.
+Roc is best described as a pure [functional programming](https://en.wikipedia.org/wiki/Functional_programming) language. Most Roc code is written with immutable values and pure functions, while effects are kept explicit and separate.
+
+Roc also offers locally mutable variables and imperative control flow—including `for`, `while`, `break`, and `return`. These features make Roc more approachable for people coming from imperative languages and can make a few algorithms clearer even for experienced Roc developers. They do not introduce shared mutable state or sacrifice function-level purity: a variable can only be reassigned inside the function where it was declared.
 
 <!-- TODO uncomment once opportunistic mutation is implemented
 ## [Opportunistic mutation](#opportunistic-mutation) {#opportunistic-mutation}
@@ -25,115 +27,112 @@ Roc has ways of detecting uniqueness at compile time, so this optimization will 
 
 ## [Immutable by default](#immutable-by-default) {#immutable-by-default}
 
-By default, Roc values are semantically immutable. In many languages, everything is mutable by default, and it's up to the programmer to "defensively" clone to avoid undesirable modification. Roc's approach means that cloning happens automatically, which can be less error-prone than defensive cloning (which might be forgotten), but <span class="nowrap">which—to be fair—can</span> also increase unintentional cloning. It's a different default with different tradeoffs.
+Roc values are semantically immutable. Passing a list, record, or other value to a function cannot let that function modify the value seen by its caller. In languages with shared mutable values, programmers often need to clone defensively to prevent unexpected changes. Roc makes that protection the default.
 
-A reliability benefit of semantic immutability is that it rules out [data races](https://en.wikipedia.org/wiki/Race_condition#Data_race). These concurrency bugs can be difficult to reproduce and time-consuming to debug, and they are only possible through direct mutation.
+A reliability benefit of semantic immutability is that it rules out [data races](https://en.wikipedia.org/wiki/Race_condition#Data_race). These concurrency bugs can be difficult to reproduce and time-consuming to debug, and they require shared mutation that Roc does not expose.
 
-Direct mutation primitives have benefits too. Some algorithms are more concise or otherwise easier to read when written with direct mutation, and direct mutation can make the performance characteristics of some operations clearer. To address this, Roc provides opt-in mutable variables (described in the next section), while keeping immutability as the default.
+Ordinary definitions are immutable too. Once `greeting = "Hello"` has introduced `greeting` in a scope, it is not intended to be reassigned or shadowed in that scope. Experienced Roc developers will generally use this functional style, with operations such as `map`, `fold`, pattern matching, and recursion.
 
-As such, Roc's design means that data races and reference cycles can be ruled out for the vast majority of code, and that functions will tend to be more amenable for chaining, while mutable variables provide an escape hatch for algorithms where direct mutation leads to clearer code.
+When local mutation makes an algorithm easier to learn or clearer to read, Roc provides an explicit alternative.
 
-## [No reassignment or shadowing by default](#no-reassignment) {#no-reassignment}
+## [Explicit local mutation](#no-reassignment) {#no-reassignment}
 
-In some languages, the following is allowed.
+Writing the same ordinary definition twice is not how Roc expresses reassignment. The compiler reports a shadowing warning for code like this:
 
-<pre><samp class="code-snippet"><span class="literal">x <span class="kw">=</span> <span class="literal">1</span>
-x <span class="kw">=</span> <span class="literal">2</span></samp></pre>
+```roc
+x = 1
+x = 2
+```
 
-In Roc, you can only execute that code when using the `--allow-errors` flag.
-That flag is intended to give you the freedom to quickly debug something or try something out even though some parts of the code contain errors.
+For intentional reassignment, declare a variable with `var` and use its `$` prefix at every subsequent reference:
 
-For cases where reassignment is the most natural way to express something, Roc provides mutable variables. These are declared with `var` and marked with a `$` prefix. For example, `var $count = 0` declares a mutable variable that can later be reassigned with `$count = $count + 1`. The `$` prefix makes it immediately clear at every use site that a value might change, preserving the readability benefits of immutability by default while providing a convenient way to express algorithms that are more natural with mutation.
+```roc
+var $count = 0
+$count = $count + 1
+```
+
+The `$` makes possible reassignment visible at every use site. A variable can only be reassigned within the same function that declared it; a nested function cannot reassign a variable captured from an outer function. This restriction keeps mutation local and preserves the containing function's purity.
+
+The same principle applies to imperative control flow. Using `for`, `while`, `break`, or `return` does not by itself make a function effectful. These constructs only control evaluation inside the current function.
+
+### [Functional and imperative styles](#functional-and-imperative) {#functional-and-imperative}
+
+For example, a list can be summed in a functional style with `fold`:
+
+```roc
+sum : List(I64) -> I64
+sum = |numbers| numbers.fold(0, |total, number| total + number)
+```
+
+The same function can use a local variable and a `for` loop:
+
+```roc
+sum : List(I64) -> I64
+sum = |numbers| {
+    var $total = 0
+    for number in numbers {
+        $total = $total + number
+    }
+    $total
+}
+```
+
+Both versions are pure: given the same list, they always return the same result and have no externally visible side effects. The first is the style experienced Roc developers will generally prefer; the second can be more familiar to beginners and useful when direct control flow makes an algorithm easier to follow.
 
 ### [Avoiding regressions](#avoiding-regressions) {#avoiding-regressions}
 
 A benefit of this design is that it makes Roc code easier to rearrange without causing regressions. Consider this code:
 
-<pre><samp class="code-snippet">func <span class="kw">=</span> <span class="kw">|</span>arg<span class="kw">|</span>
-    greeting <span class="kw">=</span> <span class="string">"Hello"</span>
-    welcome <span class="kw">=</span> <span class="kw">|</span>name<span class="kw">|</span> <span class="string">"</span><span class="kw">${</span>greeting<span class="kw">}</span><span class="string">, </span><span class="kw">${</span>name<span class="kw">}</span><span class="string">!"</span>
-
-    <span class="comment"># …</span>
-
-    message <span class="kw">=</span> welcome<span class="kw">(</span><span class="string">"friend"</span><span class="kw">)</span>
-
-    <span class="comment"># …</span></samp></pre>
-
-Suppose I decide to extract the `welcome` function to the top level, so I can reuse it elsewhere:
-
-<pre><samp class="code-snippet">func <span class="kw">=</span> <span class="kw">|</span>arg<span class="kw">|</span>
-    <span class="comment"># …</span>
-
-    message <span class="kw">=</span> welcome<span class="kw">(</span><span class="string">"Hello"</span><span class="punctuation section">,</span> <span class="string">"friend"</span><span class="kw">)</span>
-
-    <span class="comment"># …</span>
-
-welcome <span class="kw">=</span> <span class="kw">|</span>prefix<span class="punctuation section">,</span> name<span class="kw">|</span> <span class="string">"</span><span class="kw">${</span>prefix<span class="kw">}</span><span class="string">, </span><span class="kw">${</span>name<span class="kw">}</span><span class="string">!"</span></samp></pre>
-
-Even without knowing the rest of `func`, we can be confident this change will not alter the code's behavior.
-
-In contrast, suppose Roc allowed reassignment. Then it's possible something in the `# …` parts of the code could have modified `greeting` before it was used in the `message =` declaration. For example:
-
-<pre><samp class="code-snippet">func <span class="kw">=</span> <span class="kw">|</span>arg<span class="kw">|</span>
-    greeting <span class="kw">=</span> <span class="string">"Hello"</span>
-    welcome <span class="kw">=</span> <span class="kw">|</span>name<span class="kw">|</span> <span class="string">"</span><span class="kw">${</span>greeting<span class="kw">}</span><span class="string">, </span><span class="kw">${</span>name<span class="kw">}</span><span class="string">!"</span>
-
-    <span class="comment"># …</span>
-
-    <span class="kw">if</span> someCondition
-        greeting <span class="kw">=</span> <span class="string">"Hi"</span>
-        <span class="comment"># …</span>
-    <span class="kw">else</span>
-        <span class="comment"># …</span>
-
-    <span class="comment"># …</span>
-    message <span class="kw">=</span> welcome<span class="kw">(</span><span class="string">"friend"</span><span class="kw">)</span>
-    <span class="comment"># …</span></samp></pre>
-
-If we didn't read the whole function and notice that `greeting` was sometimes (but not always) reassigned from `"Hello"` to `"Hi"`, we might not have known that changing it to `message = welcome("Hello", "friend")` would cause a regression due to having the greeting always be `"Hello"`.
-
-Even if Roc disallowed reassignment but allowed shadowing, a similar regression could happen if the `welcome` function were shadowed between when it was defined here and when `message` later called it in the same scope. Because Roc allows neither shadowing nor reassignment for regular bindings, these regressions can't happen, and rearranging code can be done with more confidence. (Mutable variables, with their `$` prefix, make it obvious which names can change.)
-
-Mutable variables work naturally with Roc's `for` loop syntax. For example, here's a function that sums a list of numbers:
-
 ```roc
-sum = |num_list| {
-    var $total = 0
+make_message = |name| {
+    greeting = "Hello"
+    welcome = |recipient| "${greeting}, ${recipient}!"
 
-    for num in num_list {
-        $total = $total + num
-    }
-
-    $total
+    welcome(name)
 }
 ```
 
-Looping can also be done with convenience functions like `List.walk` or with recursion (Roc implements [tail-call optimization](https://en.wikipedia.org/wiki/Tail_call)).
+Suppose I decide to extract the `welcome` function to the top level, so I can reuse it elsewhere:
 
-## [Managed effects over side effects](#managed-effects) {#managed-effects}
+```roc
+make_message = |name| welcome("Hello", name)
 
-Many languages support first-class [asynchronous](https://en.wikipedia.org/wiki/Asynchronous_I/O) effects, which can improve a system's throughput (usually at the cost of some latency) especially in the presence of long-running I/O operations like network requests.
+welcome = |greeting, name| "${greeting}, ${name}!"
+```
 
-Asynchronous effects are commonly represented by a value such as a [Promise or Future](https://en.wikipedia.org/wiki/Futures_and_promises) (Roc calls these Tasks), which represent an effect to be performed. Tasks can be composed together, potentially while customizing concurrency properties and supporting I/O interruptions like cancellation and timeouts.
+In warning-free Roc code, neither `greeting` nor the local `welcome` can be silently reassigned between their definitions and uses. Names that can change carry the visible `$` prefix, so refactoring immutable code requires less searching for hidden mutation.
 
-Most languages also have a separate system for synchronous effects, namely [side effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)). Having two different ways to perform every I/O operation—one synchronous and one asynchronous—can lead to a lot of duplication across a language's ecosystem.
+Looping can also be expressed with `List.fold` or recursion. Roc performs tail-call optimization for eligible recursive functions.
 
-Instead of having [side effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)), Roc functions exclusively use *managed effects* in which they return descriptions of effects to run, in the form of Tasks. Tasks can be composed and chained together, until they are ultimately handed off (usually via a `main` function or something similar) to an effect runner outside the program, which actually performs the effects the tasks describe.
+## [Pure and effectful functions](#managed-effects) {#managed-effects}
 
-Having only (potentially asynchronous) *managed effects* and no (synchronous) *side effects* both simplifies the language's ecosystem and makes certain guarantees possible. For example, the combination of managed effects and semantically immutable values means all Roc functions are [pure](https://en.wikipedia.org/wiki/Pure_function)—that is, they have no side effects and always return the same answer when called with the same arguments.
+Roc makes a first-class distinction between pure and effectful functions. A pure function always returns the same answer for the same arguments and has no externally visible side effects. An effectful function may perform I/O or call another effectful function.
+
+Pure function types use `->`. Effectful function types use `=>`, and effectful function names end in `!`:
+
+```roc
+format_name : Str -> Str
+format_name = |name| "Hello, ${name.trim()}!"
+
+announce! : Str => {}
+announce! = |name| echo!(format_name(name))
+```
+
+Unlike the former `Task`-based design, current Roc code calls effectful functions directly. Pure functions cannot call effectful functions, while effectful functions can call both. The compiler infers effectfulness and checks annotations, making the effectful boundary visible in names and types.
+
+Roc's standard library contains no effectful functions. They come from the application's platform, which decides how each effect is implemented. A platform can use synchronous blocking I/O, asynchronous I/O, or another strategy appropriate to its domain.
+
+This explicit separation is another reason Roc is a pure functional language: application logic can remain pure by construction, while the smaller effectful boundary is easy to identify.
 
 ## [Pure functions](#pure-functions) {#pure-functions}
 
-Pure functions have some valuable properties, such as [referential transparency](https://en.wikipedia.org/wiki/Referential_transparency) and being trivial to [memoize](https://en.wikipedia.org/wiki/Memoization). They also have testing benefits; for example, all Roc tests which either use simulated effects (or which do not involve Tasks at all) can never flake. They either consistently pass or consistently fail. Because of this, their results can be cached, so `roc test` can skip re-running them unless their source code (including dependencies) changed. (This caching has not yet been implemented, but is planned.)
+Pure functions have valuable properties such as [referential transparency](https://en.wikipedia.org/wiki/Referential_transparency): a call can be replaced with its result without changing program behavior. They are straightforward to test because their results depend only on their arguments, and they are amenable to optimizations such as memoization and compile-time evaluation.
 
-Roc does support [tracing](https://en.wikipedia.org/wiki/Tracing_(software)) via the `dbg` keyword, an essential [debugging](https://en.wikipedia.org/wiki/Debugging) tool which is unusual among side effects in that using it should not affect the behavior of the program. As such, it typically does not impact the guarantees of pure functions in practice.
+Local variables do not change these properties. A pure function may reassign its own `$` variables internally, but callers cannot observe those intermediate states. They can only observe the function's return value.
 
-Pure functions are notably amenable to compiler optimizations, and Roc already takes advantage of them to implement [function-level dead code elimination](https://elm-lang.org/news/small-assets-without-the-headache). Here are some other examples of optimizations that will benefit from this in the future; these are planned, but not yet implemented:
+Roc permits `dbg` and `expect` inside pure functions as special development tools. Their output is for the programmer and is not part of the program's semantics, so program behavior must not depend on it.
 
-- [Loop fusion](https://en.wikipedia.org/wiki/Loop_fission_and_fusion), which can do things like combining consecutive `List.map` calls (potentially intermingled with other operations that traverse the list) into one pass over the list.
-- [Hoisting](https://en.wikipedia.org/wiki/Loop-invariant_code_motion), which moves certain operations outside loops to prevent them from being re-evaluated unnecessarily on each step of the loop. It's always safe to hoist calls to pure functions, and in some cases they can be hoisted all the way to the top level, at which point they become eligible for compile-time evaluation.
-
-There are other optimizations (some of which have yet to be considered) that pure functions enable; this is just a sample!
+Roc evaluates top-level values at compile time because they can only call pure functions. Purity can also enable optimizations such as dead-code elimination, loop fusion, and hoisting work out of loops.
 
 ## Get started
 

--- a/website/content/functional.md
+++ b/website/content/functional.md
@@ -120,7 +120,7 @@ announce! = |name| echo!(format_name(name))
 
 Unlike the former `Task`-based design, current Roc code calls effectful functions directly. Pure functions cannot call effectful functions, while effectful functions can call both. The compiler infers effectfulness and checks annotations, making the effectful boundary visible in names and types.
 
-Roc's standard library contains no effectful functions. They come from the application's platform, which decides how each effect is implemented. A platform can use synchronous blocking I/O, asynchronous I/O, or another strategy appropriate to its domain.
+The application's [platform](https://roc-lang.org/docs/main/langref/platforms/) provides effectful functions and decides how each effect is implemented. A platform can use synchronous blocking I/O, asynchronous I/O, or another strategy appropriate to its domain.
 
 This explicit separation is another reason Roc is a pure functional language: application logic can remain pure by construction, while the smaller effectful boundary is easy to identify.
 

--- a/website/content/install/nix.md
+++ b/website/content/install/nix.md
@@ -57,4 +57,4 @@ nix flake init --template github:roc-lang/roc#simple --refresh
 - [Tutorial](https://github.com/roc-lang/roc/blob/main/docs/mini-tutorial-new-compiler.md)
 - [Examples](https://www.roc-lang.org/examples)
 - [Frequently Asked Questions](https://www.roc-lang.org/faq)
-- [Roc Exercism Track](https://exercism.org/tracks/roc) (still on Roc alpha 4)
+- [Roc Exercism Track](https://exercism.org/tracks/roc)

--- a/website/content/install/other.md
+++ b/website/content/install/other.md
@@ -17,4 +17,4 @@ Note: if your system is in this "other" category, that means we did not test Roc
 - [Tutorial](https://github.com/roc-lang/roc/blob/main/docs/mini-tutorial-new-compiler.md)
 - [Examples](https://www.roc-lang.org/examples)
 - [Frequently Asked Questions](https://www.roc-lang.org/faq)
-- [Roc Exercism Track](https://exercism.org/tracks/roc) (still on Roc alpha 4)
+- [Roc Exercism Track](https://exercism.org/tracks/roc)

--- a/website/content/install/unix.md
+++ b/website/content/install/unix.md
@@ -21,4 +21,4 @@
 - [Tutorial](https://github.com/roc-lang/roc/blob/main/docs/mini-tutorial-new-compiler.md)
 - [Examples](https://www.roc-lang.org/examples)
 - [Frequently Asked Questions](https://www.roc-lang.org/faq)
-- [Roc Exercism Track](https://exercism.org/tracks/roc) (still on Roc alpha 4)
+- [Roc Exercism Track](https://exercism.org/tracks/roc)

--- a/website/content/install/windows.md
+++ b/website/content/install/windows.md
@@ -31,4 +31,4 @@
 - [Tutorial](https://github.com/roc-lang/roc/blob/main/docs/mini-tutorial-new-compiler.md)
 - [Examples](https://www.roc-lang.org/examples)
 - [Frequently Asked Questions](https://www.roc-lang.org/faq)
-- [Roc Exercism Track](https://exercism.org/tracks/roc) (still on Roc alpha 4)
+- [Roc Exercism Track](https://exercism.org/tracks/roc)


### PR DESCRIPTION
There are a number of outdated code examples and comments in `faq.md`, `friendly.md` and `functional.md`, as well as in the O.S.-specific installation pages. This PR aims to fix them. This includes a variety of things, including:

* Fix outdated code such as `List.reverse` or `List.sort`
* Fix old conventions such as `Email.isValid` instead of `Email.is_valid`
* Fix old outputs such as `── TYPE MISMATCH ──────────────────`
* Update explanation around IOs and Tasks.
* Add missing description of imperative constructs such as variables, `for`, `while`, `return`, and `break`, and explain why Roc is still a pure functional language.
* Remove the note about Exercism still being on Roc alpha 4.
