### PR TITLE
Bring back the copy button

### DIFF
--- a/website/public/compiler.js
+++ b/website/public/compiler.js
@@ -1538,8 +1538,32 @@ function setup(div) {
   div.appendChild(outputArea);
 }
 
+function setupCopyButtons() {
+  if (!navigator.clipboard?.writeText) return;
+
+  document.querySelectorAll("#example-main pre > samp").forEach((snippet) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "button-container copy-button";
+    button.textContent = "Copy";
+    button.setAttribute("aria-live", "polite");
+
+    button.addEventListener("click", () => {
+      navigator.clipboard.writeText(snippet.textContent);
+      button.textContent = "Copied!";
+    });
+    button.addEventListener("mouseleave", () => {
+      button.textContent = "Copy";
+    });
+
+    snippet.before(button);
+  });
+}
+
 // run the setup, when the DOM is finished loading
 document.addEventListener("DOMContentLoaded", () => {
+  setupCopyButtons();
+
   const interactiveWidgets = document.querySelectorAll(".roc-interactive");
   interactiveWidgets.forEach(setup);
 


### PR DESCRIPTION
I was going through the examples today and really missed this. I tried to reuse as much code/styles as what is and was there as possible. Note that it only adds the copy button to the snippets in examples (`#example-main`), I don't know if it's needed anywhere else

<img width="1037" height="275" alt="Screenshot 2026-08-17 at 2 50 33 PM" src="https://github.com/user-attachments/assets/12e03ef8-b911-4ddd-a87c-f65a7d396272" />
