### PR TITLE
Narrow down the tab size

### DIFF
--- a/website/public/site.css
+++ b/website/public/site.css
@@ -387,6 +387,7 @@ pre {
     margin-bottom: 16px;
     padding: 0 0.35rem;
     box-sizing: border-box;
+    tab-size: 4;
     background-color: var(--gray-bg);
     overflow-x: hidden;
     word-wrap: normal;


### PR DESCRIPTION
Closes #134 

<img width="788" height="810" alt="Screenshot 2026-08-20 at 1 04 32 PM" src="https://github.com/user-attachments/assets/17c7d146-a614-4665-aef4-8f7fbcf8cda1" />
